### PR TITLE
fix: use core.open() for sidebar playback to enable macOS sleep prevention

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -389,20 +389,13 @@ function handlePlayMedia(message) {
         debugLog(`Could not clear playlist before opening: ${clearError.message}`);
       }
 
-      // Use mpv loadfile with force-media-title to set the title atomically
-      // This prevents the stale title bug where the old title persists until
-      // the async setVideoTitleFromMetadata call completes
+      // We use core.open instead of mpv.command('loadfile') because core.open
+      // properly triggers IINA's native lifecycle and sleep prevention checks.
+      // Set force-media-title BEFORE core.open so mpv uses it when loadfile runs.
       if (title) {
-        try {
-          mpv.command('loadfile', [streamUrl, 'replace', '-1', `force-media-title=${title}`]);
-        } catch (error) {
-          debugLog(`mpv loadfile with title failed: ${error.message}, falling back to core.open`);
-          isReplacingPlayback = false;
-          core.open(streamUrl);
-        }
-      } else {
-        core.open(streamUrl);
+        mpv.set('force-media-title', title);
       }
+      core.open(streamUrl);
     }
 
     debugLog('Successfully initiated media opening: ' + streamUrl);


### PR DESCRIPTION
### Problem
When playing media from the Jellyfin browser sidebar, macOS sleep prevention (IINA's "Prevent screen saver" setting) did not activate, causing the display to sleep during playback. This did not affect media opened via File → Open URL, which worked correctly.

**Root cause:** The sidebar was initiating playback via mpv.command('loadfile', ...), which drives mpv directly without going through IINA's native player lifecycle. IINA's SleepPreventer is triggered by lifecycle state transitions managed by PlayerCore - bypassing that path meant updateSleepPrevention() was never called, so no power management assertion was ever created.

This can be verified with pmset -g assertions while playing via the sidebar — IINA would not appear in the listed processes.

### Fix
Replaces mpv.command('loadfile') with core.open() for same-window playback. core.open() goes through IINA's native player lifecycle, correctly transitioning the player out of the idle state and triggering sleep prevention.

To preserve the stale title fix that loadfile previously handled (setting force-media-title atomically), a pendingTitleForUrl variable now stores the title and applies it synchronously inside the iina.file-loaded event handler, achieving the same result without bypassing core.open().