### PR TITLE
Add option to report playback to the connected account

### DIFF
--- a/Info.json
+++ b/Info.json
@@ -31,7 +31,8 @@
     "open_in_new_window": true,
     "auto_login_enabled": true,
     "autoplay_next_episode": true,
-    "sync_playback_progress": true
+    "sync_playback_progress": true,
+    "use_connected_account": false
   },
   "ghRepo": "mhajder/iina-jellyfin",
   "ghVersion": 9

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Access plugin settings through IINA → Preferences → Plugins → Jellyfin:
   - Reports current playback position to Jellyfin every 10 seconds
   - Automatically marks items as watched at 95% completion
   - Resume positions sync across all your devices
+- **Report to my connected account (ignore link's API key)**: When enabled, playback progress, resume, and watched status are reported to the Jellyfin account you're logged into via the browser sidebar, instead of the account whose `api_key` is embedded in the playing URL. Useful when several people open the same shared link (e.g. via Syncplay) — each viewer's progress records into their own account. Requires a logged-in server; falls back to the URL's `api_key` if none is connected.
 - **Show on-screen notifications**: Display OSD messages when subtitles are downloaded
 - **Preferred Languages**: Comma-separated language codes (e.g., `en,eng,pol,pl`)
 - **Download all available subtitles**: Download all subtitle tracks, ignoring language preferences

--- a/pref.html
+++ b/pref.html
@@ -118,6 +118,20 @@
       </p>
     </div>
 
+    <div class="pref-section">
+      <label>
+        <input type="checkbox" data-type="bool" data-pref-key="use_connected_account" />
+        Report to my connected account (ignore link's API key)
+      </label>
+      <p class="small secondary pref-help">
+        When on, progress, resume and watched status are reported to the Jellyfin account you logged
+        into via the Jellyfin browser sidebar — instead of the account whose api_key is in the
+        playing URL. Ideal for Syncplay watch-togethers: everyone opens the same shared link, but
+        each viewer's progress records into their own account. Requires being logged in via the
+        sidebar; falls back to the URL's api_key if no account is connected.
+      </p>
+    </div>
+
     <div class="section-header">TV Series Playback</div>
 
     <div class="pref-section">

--- a/src/index.js
+++ b/src/index.js
@@ -120,13 +120,35 @@ function onFileLoaded(fileUrl) {
 
   const jellyfinInfo = updateFromFileUrl(fileUrl);
   if (jellyfinInfo) {
-    // Store session data for auto-login if enabled
-    storeJellyfinSession(jellyfinInfo.serverBase, jellyfinInfo.apiKey);
+    // Decide which credentials playback reporting (progress/resume/watched)
+    // should use. By default it's the api_key embedded in the playing URL, so
+    // it records into whoever owns that key. When "use_connected_account" is on
+    // and a server is logged in via the Jellyfin browser sidebar, report to
+    // that account instead — the item id still comes from the URL, only the
+    // server + token change. This lets several people open the SAME shared link
+    // (e.g. over Syncplay) while each records progress into their own account.
+    let reportServerBase = jellyfinInfo.serverBase;
+    let reportApiKey = jellyfinInfo.apiKey;
+    if (preferences.get('use_connected_account')) {
+      const session = getStoredJellyfinSession();
+      if (session && session.accessToken) {
+        reportServerBase = session.serverUrl;
+        reportApiKey = session.accessToken;
+        debugLog(
+          `Connected-account mode: reporting as ${session.username || session.serverName} @ ${reportServerBase} (ignoring URL api_key)`
+        );
+      } else {
+        debugLog('Connected-account mode ON but no logged-in server; falling back to URL api_key');
+      }
+    } else {
+      // Default behaviour: remember this URL's session for auto-login.
+      storeJellyfinSession(jellyfinInfo.serverBase, jellyfinInfo.apiKey);
+    }
 
     // Start playback tracking for progress sync
     if (preferences.get('sync_playback_progress')) {
       debugLog(`Starting playback tracking for: ${jellyfinInfo.itemId}`);
-      startPlaybackTracking(jellyfinInfo.serverBase, jellyfinInfo.itemId, jellyfinInfo.apiKey);
+      startPlaybackTracking(reportServerBase, jellyfinInfo.itemId, reportApiKey);
     }
 
     // Set video title from metadata if enabled


### PR DESCRIPTION
## What

Adds a new preference — **"Report to my connected account (ignore link's API key)"** (default **off**) — that controls which account playback is reported to.

By default the plugin reports progress/resume/watched using the `api_key` embedded in the playing URL. When this option is enabled and a server is logged in via the browser sidebar, tracking is reported to that **connected account** instead.

## Why

When several people watch together over a shared link (e.g. driven by [Syncplay](https://syncplay.pl/), which pushes one URL to the whole group), that URL carries a single `api_key`, so everyone's progress records into one account. With this option, each viewer logs into their own account in the sidebar and enables the toggle — then the same shared link records each person's progress into their **own** Jellyfin account.

## How

In `onFileLoaded`, only the reporting `serverBase` + `api_key` passed to `startPlaybackTracking` are swapped for the connected account's when the option is on. The item id still comes from the URL, and title/subtitle/streaming stay on the URL host. The tracking pipeline is already `(serverBase, itemId, apiKey)`-only (no `userId`), so the swap is sufficient. Falls back to the URL's `api_key` when no account is connected. Default off, so existing behavior is unchanged.

## Testing

Verified on macOS (IINA) with two real Jellyfin accounts on one server:
- Connected as account A, link carrying account B's key → **A** gets progress/resume/watched, **B** untouched.
- Connected as account B, link carrying account A's key → **B** gets them, **A** untouched.
- Toggle off → reverts to the URL's key (original behavior).
- Resume, 10s progress reporting, and 95% watched-marking all confirmed against the connected account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
