### PR TITLE
Remove deprecated sidebar permission

### DIFF
--- a/Info.json
+++ b/Info.json
@@ -13,8 +13,7 @@
     "show-osd",
     "show-alert",
     "network-request",
-    "file-system",
-    "sidebar"
+    "file-system"
   ],
   "allowedDomains": [
     "*"


### PR DESCRIPTION
According to [the plugin docs](https://docs.iina.io/pages/dev-guide.html#plugin-permissions), sidebar is not (or no longer) a valid permission.