### PR TITLE
fix: authenticate the sidebar with the plugin's own Jellyfin device id

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ let isReplacingPlayback = false; // Guard to prevent spurious stop reports durin
 const debugLog = createDebugLogger(preferences, console);
 
 const {
+  getClientIdentity,
   buildJellyfinHeaders,
   parseJellyfinUrl,
   isJellyfinUrl,
@@ -216,6 +217,10 @@ function openJellyfinStandaloneWindow(sessionData) {
     standaloneWindow.setProperty('minimizable', true);
 
     // Set up message handlers for standalone window
+    standaloneWindow.onMessage('get-client-identity', () => {
+      standaloneWindow.postMessage('client-identity', getClientIdentity());
+    });
+
     standaloneWindow.onMessage('get-session', () => {
       standaloneWindow.postMessage('session-data', sessionData);
     });
@@ -289,6 +294,7 @@ function openJellyfinStandaloneWindow(sessionData) {
 
     // Send session data after a brief delay
     setTimeout(() => {
+      standaloneWindow.postMessage('client-identity', getClientIdentity());
       // Send multi-server list (sidebar will auto-connect to active server)
       const servers = loadStoredServers();
       const activeServerId = getActiveServerId();
@@ -505,6 +511,12 @@ event.on('iina.window-loaded', () => {
   // Set up message handler for sidebar playback requests
   sidebar.onMessage('play-media', handlePlayMedia);
 
+  // The webview cannot read preferences, so it asks for the shared Jellyfin
+  // client identity (device id + version) it must authenticate with.
+  sidebar.onMessage('get-client-identity', () => {
+    sidebar.postMessage('client-identity', getClientIdentity());
+  });
+
   // Handle session requests from sidebar (backward compatible)
   sidebar.onMessage('get-session', () => {
     const sessionData = getStoredJellyfinSession();
@@ -590,6 +602,7 @@ event.on('iina.window-loaded', () => {
 
   // Send initial server data to sidebar after a brief delay
   setTimeout(() => {
+    sidebar.postMessage('client-identity', getClientIdentity());
     const servers = loadStoredServers();
     const activeServerId = getActiveServerId();
     if (servers.length > 0) {

--- a/src/lib/jellyfin-api.js
+++ b/src/lib/jellyfin-api.js
@@ -30,6 +30,21 @@ function createJellyfinApi({ http, preferences, log }) {
     return `MediaBrowser ${parts.join(', ')}`;
   }
 
+  /**
+   * The client identity used in the Authorization header. Exposed so the
+   * sidebar/standalone webviews authenticate as the same Jellyfin device as the
+   * plugin itself — Jellyfin keys sessions and tokens by DeviceId, so a
+   * hardcoded one would collide between installs.
+   */
+  function getClientIdentity() {
+    return {
+      clientName: CLIENT_NAME,
+      deviceName: DEVICE_NAME,
+      deviceId: getDeviceId(),
+      version: CLIENT_VERSION,
+    };
+  }
+
   function buildJellyfinHeaders(apiKey, extraHeaders) {
     return {
       Authorization: buildAuthorizationHeader(apiKey),
@@ -190,6 +205,7 @@ function createJellyfinApi({ http, preferences, log }) {
   }
 
   return {
+    getClientIdentity,
     buildJellyfinHeaders,
     parseJellyfinUrl,
     isJellyfinUrl,

--- a/src/ui/sidebar/lib/auth-server-methods.js
+++ b/src/ui/sidebar/lib/auth-server-methods.js
@@ -1,5 +1,45 @@
 window.createSidebarAuthServerMethods = function createSidebarAuthServerMethods(debugLog) {
   return {
+    handleClientIdentity(identity) {
+      if (!identity || !identity.deviceId) {
+        debugLog('Ignoring client identity without a device id');
+        return;
+      }
+      this.clientIdentity = identity;
+      debugLog(`Client identity set: device ${identity.deviceId}, version ${identity.version}`);
+    },
+
+    /**
+     * Build the MediaBrowser Authorization header. The device id comes from the
+     * plugin (persisted in preferences) so the webview authenticates as the
+     * same Jellyfin device as the rest of the plugin. Jellyfin keys sessions
+     * and tokens by DeviceId, so a value shared across installs would make
+     * different users collide on the same server.
+     */
+    buildAuthorizationHeader(token) {
+      const identity = this.clientIdentity || {};
+
+      if (!identity.deviceId && !this.fallbackDeviceId) {
+        // Identity message hasn't arrived — use a unique id for this webview
+        // rather than a constant shared by every install.
+        this.fallbackDeviceId = `iina-jellyfin-webview-${Date.now()}-${Math.floor(Math.random() * 1000000)}`;
+        debugLog('No client identity yet, using generated device id');
+      }
+
+      const parts = [
+        `Client="${identity.clientName || 'IINA Jellyfin Plugin'}"`,
+        `Device="${identity.deviceName || 'IINA'}"`,
+        `DeviceId="${identity.deviceId || this.fallbackDeviceId}"`,
+        `Version="${identity.version || '0.0.0'}"`,
+      ];
+
+      if (token) {
+        parts.push(`Token="${token}"`);
+      }
+
+      return `MediaBrowser ${parts.join(', ')}`;
+    },
+
     handleServersList(data) {
       if (!data) return;
       this.servers = data.servers || [];
@@ -360,8 +400,7 @@ window.createSidebarAuthServerMethods = function createSidebarAuthServerMethods(
         const initiateResponse = await httpClient.post(`${normalizedUrl}/QuickConnect/Initiate`, {
           headers: {
             'Content-Type': 'application/json',
-            Authorization:
-              'MediaBrowser Client="IINA Jellyfin Plugin", Device="IINA", DeviceId="IINA-Jellyfin-Plugin", Version="0.4.0"',
+            Authorization: this.buildAuthorizationHeader(),
           },
         });
 
@@ -450,8 +489,7 @@ window.createSidebarAuthServerMethods = function createSidebarAuthServerMethods(
           {
             headers: {
               'Content-Type': 'application/json',
-              Authorization:
-                'MediaBrowser Client="IINA Jellyfin Plugin", Device="IINA", DeviceId="IINA-Jellyfin-Plugin", Version="0.4.0"',
+              Authorization: this.buildAuthorizationHeader(),
             },
             data: JSON.stringify({ Secret: this.qcSecret }),
           }
@@ -671,8 +709,7 @@ window.createSidebarAuthServerMethods = function createSidebarAuthServerMethods(
           headers: {
             'Content-Type': 'application/json',
             Accept: 'application/json',
-            Authorization:
-              'MediaBrowser Client="IINA Jellyfin Plugin", Device="IINA", DeviceId="IINA-Jellyfin-Plugin", Version="0.4.0"',
+            Authorization: this.buildAuthorizationHeader(),
           },
           data: JSON.stringify(authData),
         });

--- a/src/ui/sidebar/sidebar.js
+++ b/src/ui/sidebar/sidebar.js
@@ -94,6 +94,10 @@ class JellyfinSidebar {
     this.searchTimeout = null;
     this.pendingSessionData = null;
 
+    // Jellyfin client identity (device id + version), pushed by the plugin
+    this.clientIdentity = null;
+    this.fallbackDeviceId = null;
+
     // Multi-server state
     this.servers = []; // Array of stored server objects
     this.activeServerId = null;
@@ -321,6 +325,11 @@ class JellyfinSidebar {
 
   setupMessageHandlers() {
     if (typeof iina !== 'undefined' && iina.onMessage) {
+      iina.onMessage('client-identity', (data) => {
+        debugLog('Received client-identity: ' + JSON.stringify(data));
+        this.handleClientIdentity(data);
+      });
+
       // Legacy session messages (backward compatible)
       iina.onMessage('session-available', (data) => {
         debugLog('Received session-available message: ' + JSON.stringify(data));
@@ -363,6 +372,8 @@ class JellyfinSidebar {
   requestSessionData() {
     debugLog('Requesting server data from main plugin');
     if (typeof iina !== 'undefined' && iina.postMessage) {
+      // Client identity is needed before any authentication request
+      iina.postMessage('get-client-identity');
       // Request multi-server list first
       iina.postMessage('get-servers');
       // Also request legacy session for backward compatibility


### PR DESCRIPTION
The webview sent DeviceId="IINA-Jellyfin-Plugin" and a stale Version="0.4.0" on every login, Quick Connect initiate and Quick Connect authenticate. Jellyfin keys sessions and tokens by DeviceId, so every install of the plugin collided on a shared device identity.

The main entry already persists a random per-install device id, so expose it as a client identity and push it to the sidebar and standalone webviews over the message channel (the webview cannot read preferences). The webview builds its Authorization header from that, falling back to a generated id rather than a shared constant if the message has not arrived yet.