### PR TITLE
fix: drop stored credentials when disconnecting from a server

### DIFF
--- a/src/ui/sidebar/lib/auth-server-methods.js
+++ b/src/ui/sidebar/lib/auth-server-methods.js
@@ -269,6 +269,31 @@ window.createSidebarAuthServerMethods = function createSidebarAuthServerMethods(
       }
     },
 
+    /**
+     * "Disconnect" in the UI: drop the connected server's stored credentials,
+     * then reset the view. Without this the access token stays in preferences
+     * and the next window silently auto-connects again.
+     */
+    logoutActiveServer() {
+      const serverId = this.currentServer?.serverId || this.activeServerId;
+
+      if (typeof iina !== 'undefined' && iina.postMessage) {
+        if (serverId) {
+          debugLog(`Removing stored credentials for server: ${serverId}`);
+          iina.postMessage('remove-server', { serverId });
+          this.servers = this.servers.filter((server) => server.id !== serverId);
+        } else {
+          // No id to target (e.g. legacy session) — clear the stored session so
+          // the token is not left behind.
+          debugLog('No server id for the active connection, clearing stored session');
+          iina.postMessage('clear-session');
+          this.servers = [];
+        }
+      }
+
+      this.disconnectFromServer();
+    },
+
     disconnectFromServer() {
       debugLog('Disconnecting from current server');
       this.currentUser = null;

--- a/src/ui/sidebar/sidebar.js
+++ b/src/ui/sidebar/sidebar.js
@@ -181,7 +181,7 @@ class JellyfinSidebar {
     });
 
     document.getElementById('logoutBtn').addEventListener('click', () => {
-      this.disconnectFromServer();
+      this.logoutActiveServer();
     });
 
     // Login form


### PR DESCRIPTION
The Disconnect button only reset in-memory state, so the access token stayed in preferences and the next window auto-connected again — nothing in the webview ever posted clear-session, leaving clearJellyfinSession unreachable.

The button now removes the connected server from storage (falling back to clearing the session when no server id is known) and then resets the view. disconnectFromServer stays a pure state reset so the per-server remove button and session-cleared handling do not recurse.