### PR TITLE
fix: repair playback, browsing and session handling across the plugin

### DIFF
--- a/help.html
+++ b/help.html
@@ -129,7 +129,11 @@
 
     <div class="section">
       <h2>Automatic Subtitle Downloads</h2>
-      <p>The plugin automatically detects Jellyfin URLs and can download subtitles when enabled:</p>
+      <p>
+        The plugin automatically detects Jellyfin URLs and can download the item's external subtitle
+        files when enabled. Subtitles embedded in the media file are left alone — IINA already reads
+        those from the file itself. Recognised URLs:
+      </p>
       <ul>
         <li>
           Jellyfin download URLs containing <code>/Items/</code> and

--- a/pref.html
+++ b/pref.html
@@ -80,7 +80,9 @@
         Enable automatic subtitle download
       </label>
       <p class="small secondary pref-help">
-        Automatically download subtitles when opening Jellyfin media URLs in IINA.
+        Automatically download external subtitle files when opening Jellyfin media URLs in IINA.
+        Subtitles embedded in the media file are not downloaded — IINA reads those directly from the
+        file.
       </p>
     </div>
 
@@ -169,8 +171,8 @@
         Download all available subtitles
       </label>
       <p class="small secondary pref-help">
-        Download all subtitle tracks regardless of language preferences. When enabled, the preferred
-        languages setting is ignored.
+        Download every external subtitle track regardless of language preferences. When enabled, the
+        preferred languages setting is ignored.
       </p>
     </div>
 

--- a/src/index.js
+++ b/src/index.js
@@ -262,11 +262,10 @@ function openJellyfinStandaloneWindow(sessionData) {
     // Load the same sidebar HTML in standalone window
     standaloneWindow.loadFile('src/ui/sidebar/index.html');
 
-    // Set window properties
-    standaloneWindow.setFrame({ x: 100, y: 100, width: 400, height: 600 });
-    standaloneWindow.setProperty('title', 'Jellyfin Browser');
-    standaloneWindow.setProperty('resizable', true);
-    standaloneWindow.setProperty('minimizable', true);
+    // Set window properties. setFrame takes four numbers (width, height, x, y)
+    // and setProperty a single object; anything else is silently ignored.
+    standaloneWindow.setFrame(400, 600, 100, 100);
+    standaloneWindow.setProperty({ title: 'Jellyfin Browser', resizable: true });
 
     // Set up message handlers for standalone window.
     // These must be registered after every loadFile() call and cannot be

--- a/src/index.js
+++ b/src/index.js
@@ -548,7 +548,10 @@ function handlePlayMediaList(message) {
     // playing (PlayerCore.open: it stores pendingUrl and closes the window
     // first), and that load replaces the playlist — appending now would be
     // wiped out a moment later.
-    const firstItemId = (String(firstItem.streamUrl).match(/\/Items\/([^/?]+)/) || [])[1] || null;
+    // Playback URLs are /Videos/{id}/stream or /Audio/{id}/stream; /Items/ is
+    // still matched for links produced by earlier versions.
+    const firstItemId =
+      (String(firstItem.streamUrl).match(/\/(?:Items|Videos|Audio)\/([^/?]+)/) || [])[1] || null;
     pendingPlaylistQueue =
       queuedItems.length > 0 ? { items: queuedItems, at: Date.now(), itemId: firstItemId } : null;
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,32 @@ const {
   playlist,
 } = iina;
 
-let isReplacingPlayback = false; // Guard to prevent spurious stop reports during file switch
+// Guard to prevent spurious stop reports during a file switch. Stored as a
+// timestamp and expired after REPLACEMENT_GUARD_MS: if the expected end-file
+// never arrives (e.g. core.open failed), a stale guard must not swallow the
+// stop report of the next file that really does finish.
+let replacingPlaybackAt = 0;
+const REPLACEMENT_GUARD_MS = 10000;
+
+function markReplacingPlayback() {
+  replacingPlaybackAt = Date.now();
+}
+
+function consumeReplacementGuard() {
+  if (!replacingPlaybackAt) {
+    return false;
+  }
+
+  const age = Date.now() - replacingPlaybackAt;
+  replacingPlaybackAt = 0;
+
+  if (age > REPLACEMENT_GUARD_MS) {
+    debugLog(`Ignoring replacement guard set ${age}ms ago (expired)`);
+    return false;
+  }
+
+  return true;
+}
 
 const debugLog = createDebugLogger(preferences, console);
 
@@ -385,7 +410,7 @@ function openInCurrentWindow(streamUrl, title) {
 
   // Set replacement guard so end-file handler doesn't send spurious stop
   if (getCurrentPlaybackSession()) {
-    isReplacingPlayback = true;
+    markReplacingPlayback();
   }
 
   // Clear any previous playlist entries to prevent stale titles
@@ -511,6 +536,7 @@ event.on('mpv.pause.changed', handlePauseChange);
 // Handle file ending (includes both natural end and replacement)
 event.on('mpv.end-file', () => {
   const queuedForAutoplay = isQueued();
+  const isReplacingPlayback = consumeReplacementGuard();
   debugLog(
     'mpv.end-file triggered, isReplacingPlayback=' +
       isReplacingPlayback +
@@ -520,7 +546,6 @@ event.on('mpv.end-file', () => {
   if (isReplacingPlayback) {
     // File is being replaced (e.g. episode transition) — don't send stop report
     debugLog('File replacement in progress, skipping stop report');
-    isReplacingPlayback = false;
     return;
   }
   if (queuedForAutoplay) {

--- a/src/index.js
+++ b/src/index.js
@@ -153,6 +153,9 @@ function isSameJellyfinHost(left, right) {
 function onFileLoaded(fileUrl) {
   debugLog(`File loaded: ${fileUrl}`);
 
+  // The first item of a queued list is playing now, so the rest can be added
+  flushPendingPlaylistQueue(fileUrl);
+
   // Stop any existing playback tracking from previous file
   stopPlaybackTracking();
 
@@ -469,6 +472,50 @@ function openInCurrentWindow(streamUrl, title) {
   core.open(streamUrl);
 }
 
+// Items waiting to join the playlist behind the one currently being opened.
+let pendingPlaylistQueue = null;
+const PENDING_QUEUE_TTL_MS = 60000;
+
+/**
+ * Append the items held back by handlePlayMediaList. Called once the first item
+ * of the list has actually loaded, so mpv's replacing load cannot discard them.
+ */
+function flushPendingPlaylistQueue(fileUrl) {
+  if (!pendingPlaylistQueue) {
+    return;
+  }
+
+  const { items, at, itemId } = pendingPlaylistQueue;
+  pendingPlaylistQueue = null;
+
+  if (Date.now() - at > PENDING_QUEUE_TTL_MS) {
+    debugLog('Queued playlist items are stale, not appending them');
+    return;
+  }
+
+  // Make sure this is the file the list started with. IINA percent-encodes the
+  // URL, so compare on the item id rather than the whole string.
+  if (itemId && fileUrl && !String(fileUrl).includes(itemId)) {
+    debugLog(`Loaded file is not the queued list's first item (${itemId}), dropping the queue`);
+    return;
+  }
+
+  try {
+    // loadfile carries per-file options, so each queued entry keeps its own
+    // title instead of showing a raw URL in the playlist.
+    for (const item of items) {
+      const args = [item.streamUrl, 'append'];
+      if (item.title) {
+        args.push('-1', `force-media-title=${item.title}`);
+      }
+      mpv.command('loadfile', args);
+    }
+    debugLog(`Appended ${items.length} queued item(s) to the playlist`);
+  } catch (error) {
+    debugLog('Could not append queued items: ' + error);
+  }
+}
+
 /**
  * Handle a request to play several items in order (e.g. a whole album).
  * A playlist only exists within one window, so this always plays in the
@@ -493,19 +540,18 @@ function handlePlayMediaList(message) {
       core.osd(`Opening: ${firstItem.title}`);
     }
 
+    // The rest can only be appended once the first item has loaded. core.open()
+    // defers its mpv loadfile for network URLs while something is still
+    // playing (PlayerCore.open: it stores pendingUrl and closes the window
+    // first), and that load replaces the playlist — appending now would be
+    // wiped out a moment later.
+    const firstItemId = (String(firstItem.streamUrl).match(/\/Items\/([^/?]+)/) || [])[1] || null;
+    pendingPlaylistQueue =
+      queuedItems.length > 0 ? { items: queuedItems, at: Date.now(), itemId: firstItemId } : null;
+
     openInCurrentWindow(firstItem.streamUrl, firstItem.title);
 
-    // Append the rest to the playlist. loadfile carries per-file options, so
-    // each queued entry keeps its own title instead of showing a raw URL.
-    for (const item of queuedItems) {
-      const args = [item.streamUrl, 'append'];
-      if (item.title) {
-        args.push('-1', `force-media-title=${item.title}`);
-      }
-      mpv.command('loadfile', args);
-    }
-
-    debugLog(`Queued ${queuedItems.length} additional item(s) in the playlist`);
+    debugLog(`Holding ${queuedItems.length} item(s) until the first one loads`);
   } catch (error) {
     debugLog('Error playing media list: ' + error);
     core.osd('Failed to play tracks');

--- a/src/index.js
+++ b/src/index.js
@@ -136,6 +136,21 @@ const {
 });
 
 /**
+ * Compare two Jellyfin base URLs by host and port, ignoring the scheme and any
+ * trailing slash, so http/https of the same server still count as one server.
+ */
+function isSameJellyfinHost(left, right) {
+  const hostOf = (url) =>
+    String(url || '')
+      .replace(/^https?:\/\//i, '')
+      .replace(/\/.*$/, '')
+      .toLowerCase();
+
+  const leftHost = hostOf(left);
+  return leftHost.length > 0 && leftHost === hostOf(right);
+}
+
+/**
  * Handle file loaded event
  */
 function onFileLoaded(fileUrl) {
@@ -158,11 +173,19 @@ function onFileLoaded(fileUrl) {
     if (preferences.get('use_connected_account')) {
       const session = getStoredJellyfinSession();
       if (session && session.accessToken) {
-        reportServerBase = session.serverUrl;
-        reportApiKey = session.accessToken;
-        debugLog(
-          `Connected-account mode: reporting as ${session.username || session.serverName} @ ${reportServerBase} (ignoring URL api_key)`
-        );
+        // Only the credentials may change, never the item id — reporting a
+        // URL's item to a different server would 404 on every request.
+        if (isSameJellyfinHost(session.serverUrl, jellyfinInfo.serverBase)) {
+          reportServerBase = session.serverUrl;
+          reportApiKey = session.accessToken;
+          debugLog(
+            `Connected-account mode: reporting as ${session.username || session.serverName} @ ${reportServerBase} (ignoring URL api_key)`
+          );
+        } else {
+          debugLog(
+            `Connected-account mode ON but the logged-in server (${session.serverUrl}) is not the one in the URL (${jellyfinInfo.serverBase}); using URL api_key`
+          );
+        }
       } else {
         debugLog('Connected-account mode ON but no logged-in server; falling back to URL api_key');
       }

--- a/src/index.js
+++ b/src/index.js
@@ -228,8 +228,19 @@ function onFileLoaded(fileUrl) {
 function showJellyfinBrowser() {
   debugLog('Attempting to show Jellyfin browser');
 
-  // Try to show sidebar directly first
-  if (sidebar && typeof sidebar.show === 'function') {
+  // The sidebar lives inside the player window, so it is only useful while that
+  // window is on screen. sidebar.show() cannot be used to detect that: it only
+  // throws while the window has never been loaded, and IINA keeps window.loaded
+  // true after the window is closed. Showing it then succeeds silently on an
+  // invisible window and the browser appears to do nothing until IINA restarts.
+  let windowAvailable = false;
+  try {
+    windowAvailable = Boolean(core.window && core.window.loaded && core.window.visible);
+  } catch (error) {
+    debugLog(`Could not read window state: ${error.message}`);
+  }
+
+  if (windowAvailable && sidebar && typeof sidebar.show === 'function') {
     try {
       sidebar.show();
       debugLog('Sidebar shown successfully');
@@ -238,7 +249,7 @@ function showJellyfinBrowser() {
       debugLog(`Direct sidebar.show() failed: ${error.message}`);
     }
   } else {
-    debugLog('Sidebar API unavailable');
+    debugLog(`No visible player window (windowAvailable=${windowAvailable}), using standalone`);
   }
 
   // Sidebar missing or threw — fall back to a standalone window.

--- a/src/index.js
+++ b/src/index.js
@@ -531,21 +531,8 @@ function handlePlayMedia(message) {
     debugLog('Error opening media: ' + error);
     core.osd('Failed to open media');
 
-    // Fallback: copy to clipboard as backup
-    try {
-      if (typeof core !== 'undefined' && core.setClipboard) {
-        core.setClipboard(streamUrl);
-        core.osd('Error opening - URL copied to clipboard');
-      } else if (typeof utils !== 'undefined' && utils.setClipboard) {
-        utils.setClipboard(streamUrl);
-        core.osd('Error opening - URL copied to clipboard');
-      } else {
-        core.osd('Failed to open - check console for URL');
-      }
-    } catch (clipboardError) {
-      debugLog('Both open and clipboard failed: ' + clipboardError);
-      core.osd('Failed to open media - check console');
-    }
+    // No clipboard API is exposed to plugins, so the URL only goes to the log
+    debugLog(`URL that failed to open: ${streamUrl}`);
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -88,9 +88,7 @@ debugLog('Jellyfin Subtitles Plugin loaded');
 const {
   startPlaybackTracking,
   stopPlaybackTracking,
-  handlePlaybackPositionChange,
   handlePauseChange,
-  markAsWatched,
   getCurrentPlaybackSession,
 } = createPlaybackTrackingManager({
   core,
@@ -554,8 +552,9 @@ function handlePlayMedia(message) {
 // Event handlers
 event.on('iina.file-loaded', onFileLoaded);
 
-// Playback tracking events for Jellyfin progress sync
-event.on('mpv.time-pos.changed', handlePlaybackPositionChange);
+// Position is sampled by the playback tracking tick. IINA does not observe
+// mpv's time-pos property, so there is no mpv.time-pos.changed event to
+// subscribe to — it drives its own time display from a periodic timer.
 
 // Pause/unpause state sync
 event.on('mpv.pause.changed', handlePauseChange);
@@ -585,14 +584,9 @@ event.on('mpv.end-file', () => {
   stopPlaybackTracking();
 });
 
-// Handle EOF reached — mark as watched if near end
-event.on('mpv.eof-reached', () => {
-  debugLog('End of file reached (eof-reached)');
-  const playbackSession = getCurrentPlaybackSession();
-  if (playbackSession && playbackSession.itemId) {
-    markAsWatched(playbackSession.serverBase, playbackSession.itemId, playbackSession.apiKey);
-  }
-});
+// Reaching the end marks the item watched from the playback tracking tick.
+// eof-reached is an mpv property, not an event, so there is no
+// mpv.eof-reached event to listen for.
 
 // Stop tracking when window closes
 event.on('iina.window-will-close', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -710,12 +710,6 @@ event.on('iina.window-loaded', () => {
     }
   });
 
-  // Also expose a global method for sidebar communication
-  global.playMedia = (streamUrl, title) => {
-    debugLog('Global playMedia called with:', streamUrl, title);
-    handlePlayMedia({ streamUrl, title });
-  };
-
   // Send initial server data to sidebar after a brief delay
   setTimeout(() => {
     sidebar.postMessage('client-identity', getClientIdentity());

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,6 @@ const {
   sidebar,
   global,
   standaloneWindow,
-  playlist,
 } = iina;
 
 // Guard to prevent spurious stop reports during a file switch. Stored as a
@@ -441,11 +440,11 @@ function openInCurrentWindow(streamUrl, title) {
     markReplacingPlayback();
   }
 
-  // Clear any previous playlist entries to prevent stale titles
+  // Clear any previous playlist entries to prevent stale titles. IINA's
+  // playlist API has no clear(), so use mpv's own command — it drops every
+  // entry except the one currently playing, which core.open replaces below.
   try {
-    if (playlist && typeof playlist.clear === 'function') {
-      playlist.clear();
-    }
+    mpv.command('playlist-clear', []);
     // Reset autoplay state when starting new playback
     clearQueuedFlag();
   } catch (clearError) {

--- a/src/index.js
+++ b/src/index.js
@@ -80,6 +80,7 @@ const {
 } = createServerSessionStore({
   preferences,
   sidebar,
+  standaloneWindow,
   log: debugLog,
 });
 
@@ -336,12 +337,8 @@ function openJellyfinStandaloneWindow(sessionData) {
 
     standaloneWindow.onMessage('remove-server', (data) => {
       if (data && data.serverId) {
+        // The store notifies both webviews itself
         removeServer(data.serverId);
-        // Also notify standalone window (removeServer only notifies sidebar)
-        standaloneWindow.postMessage('servers-updated', {
-          servers: loadStoredServers(),
-          activeServerId: getActiveServerId(),
-        });
       }
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -252,107 +252,12 @@ function showJellyfinBrowser() {
   openJellyfinStandaloneWindow(sessionData);
 }
 
-let standaloneHandlersRegistered = false;
-
-/**
- * Register the standalone window's message handlers exactly once. IINA has no
- * off(), so registering them per open would run every action once per open:
- * playing the media twice, removing a server twice, and so on.
- */
-function registerStandaloneWindowHandlers() {
-  if (standaloneHandlersRegistered) {
-    return;
-  }
-  standaloneHandlersRegistered = true;
-
-  standaloneWindow.onMessage('get-client-identity', () => {
-    standaloneWindow.postMessage('client-identity', getClientIdentity());
-  });
-
-  standaloneWindow.onMessage('get-session', () => {
-    standaloneWindow.postMessage('session-data', getStoredJellyfinSession());
-  });
-
-  standaloneWindow.onMessage('play-media', (data) => {
-    handlePlayMedia(data);
-    // Close standalone window after starting playback
-    standaloneWindow.close();
-  });
-
-  standaloneWindow.onMessage('play-media-list', (data) => {
-    handlePlayMediaList(data);
-    standaloneWindow.close();
-  });
-
-  standaloneWindow.onMessage('clear-session', () => {
-    clearJellyfinSession();
-  });
-
-  standaloneWindow.onMessage('store-session', (data) => {
-    if (data && data.serverUrl && data.accessToken) {
-      const server = addOrUpdateServer({
-        serverUrl: data.serverUrl,
-        accessToken: data.accessToken,
-        serverName: data.serverName || '',
-        userId: data.userId || '',
-        username: data.username || '',
-      });
-      if (server) {
-        setActiveServerId(server.id);
-        standaloneWindow.postMessage('servers-updated', {
-          servers: loadStoredServers(),
-          activeServerId: server.id,
-        });
-      }
-    }
-  });
-
-  // Multi-server management messages
-  standaloneWindow.onMessage('get-servers', () => {
-    const servers = loadStoredServers();
-    const activeServerId = getActiveServerId();
-    standaloneWindow.postMessage('servers-list', { servers, activeServerId });
-  });
-
-  standaloneWindow.onMessage('remove-server', (data) => {
-    if (data && data.serverId) {
-      removeServer(data.serverId);
-      // Also notify standalone window (removeServer only notifies sidebar)
-      standaloneWindow.postMessage('servers-updated', {
-        servers: loadStoredServers(),
-        activeServerId: getActiveServerId(),
-      });
-    }
-  });
-
-  standaloneWindow.onMessage('switch-server', (data) => {
-    if (data && data.serverId) {
-      switchActiveServer(data.serverId);
-    }
-  });
-
-  standaloneWindow.onMessage('open-external-url', (data) => {
-    if (data && data.url) {
-      debugLog(`Opening external URL from standalone: ${data.url}`);
-      try {
-        utils.open(data.url);
-      } catch (error) {
-        debugLog(`Failed to open external URL: ${error.message}`);
-      }
-    }
-  });
-
-  debugLog('Standalone window message listeners registered');
-}
-
 /**
  * Open Jellyfin browser in a standalone window
  */
 function openJellyfinStandaloneWindow(sessionData) {
   try {
     debugLog('Creating standalone Jellyfin browser window');
-
-    registerStandaloneWindowHandlers();
 
     // Load the same sidebar HTML in standalone window
     standaloneWindow.loadFile('src/ui/sidebar/index.html');
@@ -362,6 +267,90 @@ function openJellyfinStandaloneWindow(sessionData) {
     standaloneWindow.setProperty('title', 'Jellyfin Browser');
     standaloneWindow.setProperty('resizable', true);
     standaloneWindow.setProperty('minimizable', true);
+
+    // Set up message handlers for standalone window.
+    // These must be registered after every loadFile() call and cannot be
+    // hoisted out of this function: standaloneWindow.loadFile() clears the
+    // window's message listeners (JavascriptAPIStandaloneWindow.loadFile ->
+    // messageHub.clearListeners), which would leave the webview unable to
+    // reach the plugin at all. Re-registering is safe because the message hub
+    // keys listeners by name and replaces the previous callback.
+    standaloneWindow.onMessage('get-client-identity', () => {
+      standaloneWindow.postMessage('client-identity', getClientIdentity());
+    });
+
+    standaloneWindow.onMessage('get-session', () => {
+      standaloneWindow.postMessage('session-data', getStoredJellyfinSession());
+    });
+
+    standaloneWindow.onMessage('play-media', (data) => {
+      handlePlayMedia(data);
+      // Close standalone window after starting playback
+      standaloneWindow.close();
+    });
+
+    standaloneWindow.onMessage('play-media-list', (data) => {
+      handlePlayMediaList(data);
+      standaloneWindow.close();
+    });
+
+    standaloneWindow.onMessage('clear-session', () => {
+      clearJellyfinSession();
+    });
+
+    standaloneWindow.onMessage('store-session', (data) => {
+      if (data && data.serverUrl && data.accessToken) {
+        const server = addOrUpdateServer({
+          serverUrl: data.serverUrl,
+          accessToken: data.accessToken,
+          serverName: data.serverName || '',
+          userId: data.userId || '',
+          username: data.username || '',
+        });
+        if (server) {
+          setActiveServerId(server.id);
+          standaloneWindow.postMessage('servers-updated', {
+            servers: loadStoredServers(),
+            activeServerId: server.id,
+          });
+        }
+      }
+    });
+
+    // Multi-server management messages
+    standaloneWindow.onMessage('get-servers', () => {
+      const servers = loadStoredServers();
+      const activeServerId = getActiveServerId();
+      standaloneWindow.postMessage('servers-list', { servers, activeServerId });
+    });
+
+    standaloneWindow.onMessage('remove-server', (data) => {
+      if (data && data.serverId) {
+        removeServer(data.serverId);
+        // Also notify standalone window (removeServer only notifies sidebar)
+        standaloneWindow.postMessage('servers-updated', {
+          servers: loadStoredServers(),
+          activeServerId: getActiveServerId(),
+        });
+      }
+    });
+
+    standaloneWindow.onMessage('switch-server', (data) => {
+      if (data && data.serverId) {
+        switchActiveServer(data.serverId);
+      }
+    });
+
+    standaloneWindow.onMessage('open-external-url', (data) => {
+      if (data && data.url) {
+        debugLog(`Opening external URL from standalone: ${data.url}`);
+        try {
+          utils.open(data.url);
+        } catch (error) {
+          debugLog(`Failed to open external URL: ${error.message}`);
+        }
+      }
+    });
 
     // Open the window
     standaloneWindow.open();

--- a/src/index.js
+++ b/src/index.js
@@ -252,12 +252,107 @@ function showJellyfinBrowser() {
   openJellyfinStandaloneWindow(sessionData);
 }
 
+let standaloneHandlersRegistered = false;
+
+/**
+ * Register the standalone window's message handlers exactly once. IINA has no
+ * off(), so registering them per open would run every action once per open:
+ * playing the media twice, removing a server twice, and so on.
+ */
+function registerStandaloneWindowHandlers() {
+  if (standaloneHandlersRegistered) {
+    return;
+  }
+  standaloneHandlersRegistered = true;
+
+  standaloneWindow.onMessage('get-client-identity', () => {
+    standaloneWindow.postMessage('client-identity', getClientIdentity());
+  });
+
+  standaloneWindow.onMessage('get-session', () => {
+    standaloneWindow.postMessage('session-data', getStoredJellyfinSession());
+  });
+
+  standaloneWindow.onMessage('play-media', (data) => {
+    handlePlayMedia(data);
+    // Close standalone window after starting playback
+    standaloneWindow.close();
+  });
+
+  standaloneWindow.onMessage('play-media-list', (data) => {
+    handlePlayMediaList(data);
+    standaloneWindow.close();
+  });
+
+  standaloneWindow.onMessage('clear-session', () => {
+    clearJellyfinSession();
+  });
+
+  standaloneWindow.onMessage('store-session', (data) => {
+    if (data && data.serverUrl && data.accessToken) {
+      const server = addOrUpdateServer({
+        serverUrl: data.serverUrl,
+        accessToken: data.accessToken,
+        serverName: data.serverName || '',
+        userId: data.userId || '',
+        username: data.username || '',
+      });
+      if (server) {
+        setActiveServerId(server.id);
+        standaloneWindow.postMessage('servers-updated', {
+          servers: loadStoredServers(),
+          activeServerId: server.id,
+        });
+      }
+    }
+  });
+
+  // Multi-server management messages
+  standaloneWindow.onMessage('get-servers', () => {
+    const servers = loadStoredServers();
+    const activeServerId = getActiveServerId();
+    standaloneWindow.postMessage('servers-list', { servers, activeServerId });
+  });
+
+  standaloneWindow.onMessage('remove-server', (data) => {
+    if (data && data.serverId) {
+      removeServer(data.serverId);
+      // Also notify standalone window (removeServer only notifies sidebar)
+      standaloneWindow.postMessage('servers-updated', {
+        servers: loadStoredServers(),
+        activeServerId: getActiveServerId(),
+      });
+    }
+  });
+
+  standaloneWindow.onMessage('switch-server', (data) => {
+    if (data && data.serverId) {
+      switchActiveServer(data.serverId);
+    }
+  });
+
+  standaloneWindow.onMessage('open-external-url', (data) => {
+    if (data && data.url) {
+      debugLog(`Opening external URL from standalone: ${data.url}`);
+      try {
+        utils.open(data.url);
+      } catch (error) {
+        debugLog(`Failed to open external URL: ${error.message}`);
+      }
+    }
+  });
+
+  debugLog('Standalone window message listeners registered');
+}
+
 /**
  * Open Jellyfin browser in a standalone window
  */
 function openJellyfinStandaloneWindow(sessionData) {
   try {
     debugLog('Creating standalone Jellyfin browser window');
+
+    registerStandaloneWindowHandlers();
 
     // Load the same sidebar HTML in standalone window
     standaloneWindow.loadFile('src/ui/sidebar/index.html');
@@ -267,84 +362,6 @@ function openJellyfinStandaloneWindow(sessionData) {
     standaloneWindow.setProperty('title', 'Jellyfin Browser');
     standaloneWindow.setProperty('resizable', true);
     standaloneWindow.setProperty('minimizable', true);
-
-    // Set up message handlers for standalone window
-    standaloneWindow.onMessage('get-client-identity', () => {
-      standaloneWindow.postMessage('client-identity', getClientIdentity());
-    });
-
-    standaloneWindow.onMessage('get-session', () => {
-      standaloneWindow.postMessage('session-data', sessionData);
-    });
-
-    standaloneWindow.onMessage('play-media', (data) => {
-      handlePlayMedia(data);
-      // Close standalone window after starting playback
-      standaloneWindow.close();
-    });
-
-    standaloneWindow.onMessage('play-media-list', (data) => {
-      handlePlayMediaList(data);
-      standaloneWindow.close();
-    });
-
-    standaloneWindow.onMessage('clear-session', () => {
-      clearJellyfinSession();
-    });
-
-    standaloneWindow.onMessage('store-session', (data) => {
-      if (data && data.serverUrl && data.accessToken) {
-        const server = addOrUpdateServer({
-          serverUrl: data.serverUrl,
-          accessToken: data.accessToken,
-          serverName: data.serverName || '',
-          userId: data.userId || '',
-          username: data.username || '',
-        });
-        if (server) {
-          setActiveServerId(server.id);
-          standaloneWindow.postMessage('servers-updated', {
-            servers: loadStoredServers(),
-            activeServerId: server.id,
-          });
-        }
-      }
-    });
-
-    // Multi-server management messages
-    standaloneWindow.onMessage('get-servers', () => {
-      const servers = loadStoredServers();
-      const activeServerId = getActiveServerId();
-      standaloneWindow.postMessage('servers-list', { servers, activeServerId });
-    });
-
-    standaloneWindow.onMessage('remove-server', (data) => {
-      if (data && data.serverId) {
-        removeServer(data.serverId);
-        // Also notify standalone window (removeServer only notifies sidebar)
-        standaloneWindow.postMessage('servers-updated', {
-          servers: loadStoredServers(),
-          activeServerId: getActiveServerId(),
-        });
-      }
-    });
-
-    standaloneWindow.onMessage('switch-server', (data) => {
-      if (data && data.serverId) {
-        switchActiveServer(data.serverId);
-      }
-    });
-
-    standaloneWindow.onMessage('open-external-url', (data) => {
-      if (data && data.url) {
-        debugLog(`Opening external URL from standalone: ${data.url}`);
-        try {
-          utils.open(data.url);
-        } catch (error) {
-          debugLog(`Failed to open external URL: ${error.message}`);
-        }
-      }
-    });
 
     // Open the window
     standaloneWindow.open();

--- a/src/index.js
+++ b/src/index.js
@@ -400,7 +400,10 @@ menu.addItem(
     () => {
       showJellyfinBrowser();
     },
-    { keyBinding: 'Cmd+Shift+J' }
+    // mpv key binding format: Command is "Meta". Unknown modifier names are
+    // dropped silently, so "Cmd+Shift+J" would bind plain Shift+J and steal
+    // IINA's own "cycle subtitles backward" shortcut.
+    { keyBinding: 'Meta+Shift+j' }
   )
 );
 

--- a/src/lib/autoplay-manager.js
+++ b/src/lib/autoplay-manager.js
@@ -81,7 +81,9 @@ function createAutoplayManager({
       const seriesId = metadata.SeriesId;
       const seasonId = metadata.SeasonId;
       const seriesName = metadata.SeriesName || '';
-      const seasonNumber = Number(metadata.ParentIndexNumber) || 1;
+      // Specials are season 0, so a plain || 1 would relabel them as season 1
+      const parsedSeasonNumber = Number(metadata.ParentIndexNumber ?? 1);
+      const seasonNumber = Number.isFinite(parsedSeasonNumber) ? parsedSeasonNumber : 1;
       const episodeIndexNumber = Number(metadata.IndexNumber) || 0;
 
       if (!seriesId || !seasonId) {

--- a/src/lib/autoplay-manager.js
+++ b/src/lib/autoplay-manager.js
@@ -111,7 +111,11 @@ function createAutoplayManager({
     try {
       const episodes = await fetchSeriesEpisodes(serverBase, seriesId, seasonId, apiKey);
       const currentEpNum = Number(currentEpisodeNumber);
-      const nextEpisode = episodes.find((episode) => episode.indexNumber === currentEpNum + 1);
+      // The list is sorted by episode number, so the first entry above the
+      // current one is the next episode. Matching currentEpNum + 1 exactly
+      // would end the series at any gap: a missing episode, a double episode
+      // counted as two numbers, or a season that does not start at 1.
+      const nextEpisode = episodes.find((episode) => episode.indexNumber > currentEpNum);
 
       if (nextEpisode) {
         log(

--- a/src/lib/autoplay-manager.js
+++ b/src/lib/autoplay-manager.js
@@ -289,7 +289,8 @@ function createAutoplayManager({
           return;
         }
 
-        const seasonNum = nextEpisode.seasonNumber || seriesInfo.seasonNumber;
+        // ?? rather than ||: season 0 is a real season number
+        const seasonNum = nextEpisode.seasonNumber ?? seriesInfo.seasonNumber;
         queueNextEpisode(nextEpisode, seriesInfo.seriesName, seasonNum);
 
         log(`Autoplay setup complete — queued next episode: ${nextEpisode.name}`);

--- a/src/lib/autoplay-manager.js
+++ b/src/lib/autoplay-manager.js
@@ -227,30 +227,6 @@ function createAutoplayManager({
     }
   }
 
-  function storeCurrentEpisodeInfo(episodeId, seriesInfo) {
-    try {
-      if (!seriesInfo) {
-        log('Series info is null, clearing stored episode info');
-        preferences.set('last_episode_id', '');
-        preferences.set('last_series_id', '');
-        preferences.set('last_season_id', '');
-        preferences.set('last_episode_number', 0);
-        return;
-      }
-
-      log(
-        `Storing episode info for autoplay - Episode: ${episodeId}, Series: ${seriesInfo.seriesId}`
-      );
-      preferences.set('last_episode_id', episodeId);
-      preferences.set('last_series_id', seriesInfo.seriesId);
-      preferences.set('last_season_id', seriesInfo.seasonId);
-      preferences.set('last_episode_number', seriesInfo.currentEpisodeNumber);
-      preferences.sync();
-    } catch (error) {
-      log(`Error storing episode info: ${error.message}`);
-    }
-  }
-
   function setupAutoplayForEpisode(serverBase, episodeId, apiKey) {
     if (lastProcessedEpisodeId === episodeId) {
       log(`Episode ${episodeId} already being processed, skipping duplicate setup`);
@@ -289,8 +265,6 @@ function createAutoplayManager({
           log(`Series changed from ${lastProcessedSeriesId} to ${seriesInfo.seriesId}`);
           lastProcessedSeriesId = seriesInfo.seriesId;
         }
-
-        storeCurrentEpisodeInfo(episodeId, seriesInfo);
 
         const nextEpisode = await resolveNextEpisode(
           serverBase,

--- a/src/lib/autoplay-manager.js
+++ b/src/lib/autoplay-manager.js
@@ -20,7 +20,7 @@ function createAutoplayManager({
 
       const queryParams = [
         'seasonId=' + encodeURIComponent(seasonId),
-        'fields=' + encodeURIComponent('MediaSources,Path,LocationType,IsFolder,CanDownload'),
+        'fields=' + encodeURIComponent('MediaSources,Path,LocationType,IsFolder'),
       ].join('&');
 
       const response = await http.get(
@@ -44,16 +44,15 @@ function createAutoplayManager({
         return [];
       }
 
-      const episodes = episodeData.Items.filter((episode) => {
-        const hasMediaSources = episode.MediaSources && episode.MediaSources.length > 0;
-        const canDownload = episode.CanDownload !== false;
-        return hasMediaSources && canDownload;
-      }).map((episode) => ({
+      // Playback streams the item, so download permission is irrelevant here
+      const episodes = episodeData.Items.filter(
+        (episode) => episode.MediaSources && episode.MediaSources.length > 0
+      ).map((episode) => ({
         id: episode.Id,
         name: episode.Name,
         indexNumber: Number(episode.IndexNumber) || 0,
         duration: episode.RunTimeTicks,
-        playUrl: `${serverBase}/Items/${episode.Id}/Download?api_key=${apiKey}`,
+        playUrl: `${serverBase}/Videos/${episode.Id}/stream?static=true&api_key=${apiKey}`,
       }));
 
       episodes.sort((left, right) => left.indexNumber - right.indexNumber);

--- a/src/lib/debug-log.js
+++ b/src/lib/debug-log.js
@@ -3,6 +3,17 @@
 const MAX_LOG_LENGTH = 600;
 const MAX_KEYS = 8;
 
+// Credentials travel in URLs (api_key=...) and in the MediaBrowser
+// Authorization header (Token="..."). Strip them from anything we log.
+const SECRET_QUERY_PARAM = /([?&](?:api_key|apikey|api-key|x-emby-token)=)[^&\s"']+/gi;
+const SECRET_TOKEN_FIELD = /((?:token|accesstoken|api_key)"?\s*[:=]\s*"?)[A-Za-z0-9._-]{8,}/gi;
+
+function redactSecrets(value) {
+  return String(value)
+    .replace(SECRET_QUERY_PARAM, '$1[redacted]')
+    .replace(SECRET_TOKEN_FIELD, '$1[redacted]');
+}
+
 function truncateText(value, maxLength = MAX_LOG_LENGTH) {
   if (value.length <= maxLength) {
     return value;
@@ -72,7 +83,7 @@ function serializeArg(arg) {
 function createDebugLogger(preferences, loggerConsole) {
   return function debugLog(...parts) {
     if (preferences?.get?.('debug_logging')) {
-      const text = parts.map(serializeArg).join(' | ');
+      const text = redactSecrets(parts.map(serializeArg).join(' | '));
       loggerConsole.log(`DEBUG: ${text}`);
     }
   };
@@ -80,4 +91,5 @@ function createDebugLogger(preferences, loggerConsole) {
 
 module.exports = {
   createDebugLogger,
+  redactSecrets,
 };

--- a/src/lib/jellyfin-api.js
+++ b/src/lib/jellyfin-api.js
@@ -69,16 +69,19 @@ function createJellyfinApi({ http, preferences, log }) {
 
       const protocol = protocolMatch[1];
       const host = protocolMatch[2];
-      const serverBase = `${protocol}://${host}`;
-
-      log(`Extracted serverBase: ${serverBase}`);
 
       const urlParts = url.split('?');
-      const pathname = urlParts[0].replace(/^https?:\/\/[^/]+/, '');
       const queryString = urlParts[1] || '';
 
+      // Everything before the media route is the server, not just the host: a
+      // Jellyfin behind a reverse proxy subpath (https://example.com/jellyfin)
+      // would otherwise have every later API call sent to the bare domain.
+      const baseMatch = urlParts[0].match(/^(https?:\/\/[^/]+.*?)\/(?:Items|Videos|Audio)\//i);
+      const serverBase = baseMatch ? baseMatch[1] : `${protocol}://${host}`;
+      const pathname = urlParts[0].slice(serverBase.length);
+
+      log(`Extracted serverBase: ${serverBase}`);
       log(`Extracted pathname: ${pathname}`);
-      log(`Extracted queryString: ${queryString}`);
 
       // Playback uses the streaming routes (/Videos/{id}/stream,
       // /Audio/{id}/stream); /Items/{id}/... is still accepted so links made by
@@ -95,7 +98,11 @@ function createJellyfinApi({ http, preferences, log }) {
 
       let apiKey = null;
       if (queryString) {
-        const apiKeyMatch = queryString.match(/(?:^|&)api_key=([^&]+)/);
+        // Jellyfin binds query parameters case-insensitively, so links made by
+        // other tools may spell the token differently.
+        const apiKeyMatch = queryString.match(
+          /(?:^|&)(?:api_key|apikey|api-key|x-emby-token)=([^&]+)/i
+        );
         if (apiKeyMatch) {
           apiKey = decodeURIComponent(apiKeyMatch[1]);
         }
@@ -131,7 +138,7 @@ function createJellyfinApi({ http, preferences, log }) {
     }
 
     return (
-      (url.includes('/Items/') && url.includes('api_key=')) ||
+      (url.includes('/Items/') && /[?&](?:api_key|apikey|api-key|x-emby-token)=/i.test(url)) ||
       url.includes('jellyfin') ||
       url.includes('/Audio/') ||
       url.includes('/Videos/')

--- a/src/lib/jellyfin-api.js
+++ b/src/lib/jellyfin-api.js
@@ -123,12 +123,18 @@ function createJellyfinApi({ http, preferences, log }) {
   }
 
   function isJellyfinUrl(url) {
+    // Only remote URLs can be Jellyfin. Without this a local file such as
+    // /Users/me/Videos/movie.mp4 matches on "/Videos/" and every playback
+    // triggers metadata lookups that cannot succeed.
+    if (!url || !/^https?:\/\//i.test(url)) {
+      return false;
+    }
+
     return (
-      url &&
-      ((url.includes('/Items/') && url.includes('api_key=')) ||
-        url.includes('jellyfin') ||
-        url.includes('/Audio/') ||
-        url.includes('/Videos/'))
+      (url.includes('/Items/') && url.includes('api_key=')) ||
+      url.includes('jellyfin') ||
+      url.includes('/Audio/') ||
+      url.includes('/Videos/')
     );
   }
 

--- a/src/lib/jellyfin-api.js
+++ b/src/lib/jellyfin-api.js
@@ -80,11 +80,14 @@ function createJellyfinApi({ http, preferences, log }) {
       log(`Extracted pathname: ${pathname}`);
       log(`Extracted queryString: ${queryString}`);
 
-      const pathMatch = pathname.match(/\/Items\/([^/]+)/);
+      // Playback uses the streaming routes (/Videos/{id}/stream,
+      // /Audio/{id}/stream); /Items/{id}/... is still accepted so links made by
+      // earlier versions, and Jellyfin download links, keep working.
+      const pathMatch = pathname.match(/\/(?:Items|Videos|Audio)\/([^/]+)/);
       log(`Path match result: ${pathMatch ? pathMatch[0] : 'no match'}`);
 
       if (!pathMatch) {
-        log(`No /Items/ pattern found in pathname: ${pathname}`);
+        log(`No item id found in pathname: ${pathname}`);
         return null;
       }
 

--- a/src/lib/media-actions.js
+++ b/src/lib/media-actions.js
@@ -241,11 +241,10 @@ function createMediaActionsManager({
 
     if (!currentUrl) {
       try {
-        log('No stored URL, checking core.status');
-        const currentFile = core.status.url || core.status.path;
-        log(`core.status.url = "${core.status.url}"`);
-        log(`core.status.path = "${core.status.path}"`);
-        log(`currentFile = "${currentFile}"`);
+        // core.status has no "path"; url is the only file location it exposes,
+        // and IINA returns it percent-decoded.
+        const currentFile = core.status.url;
+        log(`No stored URL, core.status.url = "${currentFile}"`);
 
         if (currentFile && isJellyfinUrl(currentFile)) {
           currentUrl = currentFile;

--- a/src/lib/media-actions.js
+++ b/src/lib/media-actions.js
@@ -73,38 +73,20 @@ function createMediaActionsManager({
     }
   }
 
-  async function downloadSubtitle(serverBase, itemId, streamIndex, apiKey, language, codec) {
-    try {
-      const subtitleUrl = `${serverBase}/Videos/${itemId}/${streamIndex}/Subtitles.${codec}?api_key=${apiKey}`;
-      const sanitizedItemId = String(itemId).replace(/[^a-zA-Z0-9_-]/g, '_');
-      const sanitizedLanguage = String(language).replace(/[^a-zA-Z0-9_-]/g, '_');
-      const sanitizedCodec = String(codec).replace(/[^a-zA-Z0-9_-]/g, '_');
-      const fileName = `jellyfin_${sanitizedItemId}_${streamIndex}_${sanitizedLanguage}.${sanitizedCodec}`;
-      const localPath = `@tmp/${fileName}`;
-
-      log(`Downloading subtitle: ${subtitleUrl}`);
-
-      await http.download(subtitleUrl, localPath);
-
-      const resolvedPath = utils.resolvePath(localPath);
-      core.subtitle.loadTrack(resolvedPath);
-
-      log(`Subtitle loaded: ${resolvedPath}`);
-
-      if (preferences.get('show_notifications')) {
-        core.osd(`Loaded ${language} subtitle`);
-      }
-
-      return true;
-    } catch (error) {
-      log(`Error downloading subtitle: ${error.message}`);
-      return false;
-    }
+  function subtitleExtensionForCodec(codec) {
+    if (codec === 'subrip') return 'srt';
+    if (codec === 'webvtt' || codec === 'vtt') return 'vtt';
+    if (codec === 'ass') return 'ass';
+    if (codec === 'ssa') return 'ssa';
+    if (codec && codec.toLowerCase().includes('srt')) return 'srt';
+    if (codec && codec.toLowerCase().includes('vtt')) return 'vtt';
+    return 'srt';
   }
 
   async function downloadExternalSubtitle(
     serverBase,
     itemId,
+    mediaSourceId,
     streamIndex,
     subtitlePath,
     apiKey,
@@ -112,16 +94,9 @@ function createMediaActionsManager({
     codec
   ) {
     try {
-      let extension = 'srt';
-      if (codec === 'subrip') extension = 'srt';
-      else if (codec === 'webvtt') extension = 'vtt';
-      else if (codec === 'ass') extension = 'ass';
-      else if (codec === 'ssa') extension = 'ssa';
-      else if (codec === 'vtt') extension = 'vtt';
-      else if (codec && codec.toLowerCase().includes('srt')) extension = 'srt';
-      else if (codec && codec.toLowerCase().includes('vtt')) extension = 'vtt';
+      const extension = subtitleExtensionForCodec(codec);
 
-      const subtitleUrl = `${serverBase}/Videos/${itemId}/${itemId}/Subtitles/${streamIndex}/stream.${extension}?api_key=${apiKey}`;
+      const subtitleUrl = `${serverBase}/Videos/${itemId}/${mediaSourceId || itemId}/Subtitles/${streamIndex}/stream.${extension}?api_key=${apiKey}`;
 
       let fileName;
       if (subtitlePath) {
@@ -175,11 +150,18 @@ function createMediaActionsManager({
       const mediaSource = playbackInfo.MediaSources[0];
       const mediaStreams = mediaSource.MediaStreams || [];
 
+      // External sidecar files only. Embedded tracks would have to be extracted
+      // by the server on demand, which takes minutes for large remuxes, and
+      // mpv already exposes them from the file itself.
       const subtitleStreams = mediaStreams.filter(
-        (stream) => stream.Type === 'Subtitle' && stream.IsTextSubtitleStream
+        (stream) =>
+          stream.Type === 'Subtitle' &&
+          stream.IsTextSubtitleStream &&
+          stream.IsExternal &&
+          stream.Path
       );
 
-      log(`Found ${subtitleStreams.length} subtitle streams`);
+      log(`Found ${subtitleStreams.length} external subtitle stream(s)`);
 
       const preferredLanguages = (preferences.get('preferred_languages') || 'en,eng')
         .split(',')
@@ -205,25 +187,22 @@ function createMediaActionsManager({
           continue;
         }
 
-        log(
-          `Processing subtitle: ${language} (${codec}) - Index: ${stream.Index}, External: ${stream.IsExternal}`
-        );
+        log(`Processing external subtitle: ${language} (${codec}) - Index: ${stream.Index}`);
 
         try {
-          if (stream.IsExternal && stream.Path) {
-            await downloadExternalSubtitle(
-              serverBase,
-              itemId,
-              stream.Index,
-              stream.Path,
-              apiKey,
-              language,
-              codec
-            );
-          } else {
-            await downloadSubtitle(serverBase, itemId, stream.Index, apiKey, language, codec);
+          const downloaded = await downloadExternalSubtitle(
+            serverBase,
+            itemId,
+            mediaSource.Id,
+            stream.Index,
+            stream.Path,
+            apiKey,
+            language,
+            codec
+          );
+          if (downloaded) {
+            downloadedCount++;
           }
-          downloadedCount++;
         } catch (error) {
           log(`Failed to download subtitle ${language}: ${error.message}`);
         }
@@ -232,9 +211,9 @@ function createMediaActionsManager({
       if (downloadedCount > 0 && preferences.get('show_notifications')) {
         core.osd(`Downloaded ${downloadedCount} subtitle(s)`);
       } else if (downloadedCount === 0) {
-        log('No subtitles downloaded');
+        log('No external subtitles downloaded');
         if (preferences.get('show_notifications')) {
-          core.osd('No matching subtitles found');
+          core.osd('No matching external subtitles found');
         }
       }
     } catch (error) {

--- a/src/lib/media-actions.js
+++ b/src/lib/media-actions.js
@@ -154,11 +154,10 @@ function createMediaActionsManager({
       // by the server on demand, which takes minutes for large remuxes, and
       // mpv already exposes them from the file itself.
       const subtitleStreams = mediaStreams.filter(
-        (stream) =>
-          stream.Type === 'Subtitle' &&
-          stream.IsTextSubtitleStream &&
-          stream.IsExternal &&
-          stream.Path
+        // IsExternal is what identifies a sidecar file. Path is only used to
+        // name the download and Jellyfin omits it for non-admin accounts, so
+        // requiring it here would hide every subtitle from those users.
+        (stream) => stream.Type === 'Subtitle' && stream.IsTextSubtitleStream && stream.IsExternal
       );
 
       log(`Found ${subtitleStreams.length} external subtitle stream(s)`);

--- a/src/lib/media-actions.js
+++ b/src/lib/media-actions.js
@@ -98,18 +98,21 @@ function createMediaActionsManager({
 
       const subtitleUrl = `${serverBase}/Videos/${itemId}/${mediaSourceId || itemId}/Subtitles/${streamIndex}/stream.${extension}?api_key=${apiKey}`;
 
-      let fileName;
+      // Everything lands in one @tmp directory, so the name has to identify the
+      // item and the track. Server-side names like "English.srt" repeat across
+      // the library and would otherwise overwrite each other.
+      const sanitizedItemId = String(itemId).replace(/[^a-zA-Z0-9_-]/g, '_');
+      let suffix;
       if (subtitlePath) {
         const pathParts = subtitlePath.split(/[/\\]/);
-        const originalName = pathParts[pathParts.length - 1];
-        fileName = originalName.replace(/[^a-zA-Z0-9._-]/g, '_');
-        log(`Using sanitized filename: ${fileName}`);
+        suffix = pathParts[pathParts.length - 1].replace(/[^a-zA-Z0-9._-]/g, '_');
       } else {
-        const sanitizedItemId = String(itemId).replace(/[^a-zA-Z0-9_-]/g, '_');
         const sanitizedLanguage = String(language).replace(/[^a-zA-Z0-9_-]/g, '_');
-        fileName = `jellyfin_external_${sanitizedItemId}_${streamIndex}_${sanitizedLanguage}.${extension}`;
-        log(`Using generated filename: ${fileName}`);
+        suffix = `${sanitizedLanguage}.${extension}`;
       }
+
+      const fileName = `jellyfin_${sanitizedItemId}_${streamIndex}_${suffix}`;
+      log(`Using filename: ${fileName}`);
 
       const localPath = `@tmp/${fileName}`;
 

--- a/src/lib/playback-tracking.js
+++ b/src/lib/playback-tracking.js
@@ -431,19 +431,6 @@ function createPlaybackTrackingManager({
     playbackTickCount = 0;
   }
 
-  function handlePlaybackPositionChange() {
-    if (!currentPlaybackSession) return;
-
-    try {
-      const position = core.status.position;
-      if (position !== null && position !== undefined && position > 0) {
-        lastKnownPosition = position;
-      }
-    } catch (error) {
-      log(`Error in position change handler: ${error.message}`);
-    }
-  }
-
   function handlePauseChange() {
     if (!currentPlaybackSession) return;
 
@@ -514,7 +501,6 @@ function createPlaybackTrackingManager({
   return {
     startPlaybackTracking,
     stopPlaybackTracking,
-    handlePlaybackPositionChange,
     handlePauseChange,
     markAsWatched,
     getCurrentPlaybackSession,

--- a/src/lib/playback-tracking.js
+++ b/src/lib/playback-tracking.js
@@ -17,8 +17,31 @@ function createPlaybackTrackingManager({
   let sessionRequestCounter = 0;
   let lastReportedPosition = 0;
   let lastKnownPosition = 0;
+  // A position of 0 means two different things: the file has not started yet
+  // (including the moment before the resume seek runs), or the user rewound to
+  // the beginning. Only after a position above 0 has been seen is 0 a real
+  // playback position worth reporting.
+  let hasStartedPlayback = false;
   let playbackTickCount = 0;
   let playbackTickTimer = null;
+
+  /**
+   * Current playback position, or null when it carries no information yet.
+   */
+  function samplePosition() {
+    const position = core.status.position;
+
+    if (position === null || position === undefined || position < 0) {
+      return null;
+    }
+
+    if (position > 0) {
+      hasStartedPlayback = true;
+      return position;
+    }
+
+    return hasStartedPlayback ? 0 : null;
+  }
 
   const PLAYBACK_TICK_INTERVAL = 1000;
   const PROGRESS_REPORT_TICKS = 10;
@@ -69,6 +92,12 @@ function createPlaybackTrackingManager({
 
     try {
       const resumePosition = await fetchResumePosition(serverBase, itemId, apiKey);
+
+      // Keep what the server had, so stopping without playing anything can
+      // report it back unchanged instead of resetting the item.
+      if (session) {
+        session.resumePosition = resumePosition ?? 0;
+      }
 
       if (resumePosition === null || resumePosition < 15) {
         log('No significant resume position, starting from beginning');
@@ -320,6 +349,7 @@ function createPlaybackTrackingManager({
       playSessionId,
       mediaSourceId,
       startTime: Date.now(),
+      resumePosition: null,
       duration: null,
       hasReportedWatched: false,
     };
@@ -353,8 +383,8 @@ function createPlaybackTrackingManager({
       }
 
       try {
-        const position = core.status.position;
-        if (position !== null && position !== undefined && position > 0) {
+        const position = samplePosition();
+        if (position !== null) {
           lastKnownPosition = position;
         }
 
@@ -435,8 +465,8 @@ function createPlaybackTrackingManager({
     if (!currentPlaybackSession) return;
 
     try {
-      const position = core.status.position;
-      if (position !== null && position !== undefined && position > 0) {
+      const position = samplePosition();
+      if (position !== null) {
         lastKnownPosition = position;
       }
 
@@ -473,16 +503,20 @@ function createPlaybackTrackingManager({
 
       let finalPosition = lastKnownPosition;
       try {
-        const position = core.status.position;
-        if (position !== null && position !== undefined && position > 0) {
+        const position = samplePosition();
+        if (position !== null) {
           finalPosition = position;
         }
       } catch {
         log(`Could not get final position from core, using lastKnownPosition: ${finalPosition}`);
       }
 
-      if (finalPosition <= 0) {
-        finalPosition = lastReportedPosition;
+      if (!hasStartedPlayback) {
+        // Nothing ever played, so report what the item already had. Sending 0
+        // here would drop it out of Continue Watching just for being opened.
+        const preserved = currentPlaybackSession.resumePosition ?? lastReportedPosition;
+        log(`No playback observed, reporting the stored position (${preserved}s)`);
+        finalPosition = preserved;
       }
 
       reportPlaybackStop(serverBase, itemId, apiKey, finalPosition, playSessionId, mediaSourceId);
@@ -490,6 +524,7 @@ function createPlaybackTrackingManager({
       currentPlaybackSession = null;
       lastReportedPosition = 0;
       lastKnownPosition = 0;
+      hasStartedPlayback = false;
       log('Playback session ended');
     }
   }

--- a/src/lib/playback-tracking.js
+++ b/src/lib/playback-tracking.js
@@ -403,6 +403,17 @@ function createPlaybackTrackingManager({
           const remaining = duration - lastKnownPosition;
           if (remaining <= 0.5) {
             log('EOF detected via tick, stopping playback tracking');
+
+            // This runs before mpv reports eof-reached and clears the session,
+            // so the watched state has to be sent from here. The progress
+            // threshold above only runs every PROGRESS_REPORT_TICKS ticks and
+            // can be missed entirely on short files or after a seek to the end.
+            if (!currentPlaybackSession.hasReportedWatched) {
+              const finished = currentPlaybackSession;
+              finished.hasReportedWatched = true;
+              markAsWatched(finished.serverBase, finished.itemId, finished.apiKey);
+            }
+
             stopPlaybackTracking();
           }
         }

--- a/src/lib/server-session-store.js
+++ b/src/lib/server-session-store.js
@@ -1,6 +1,19 @@
 'use strict';
 
-function createServerSessionStore({ preferences, sidebar, log }) {
+function createServerSessionStore({ preferences, sidebar, standaloneWindow, log }) {
+  /**
+   * Both browser surfaces show the same server list, and either can be the one
+   * the user is acting in, so state changes go to both. Posting to a webview
+   * that was never created is a no-op inside IINA.
+   */
+  function notifyViews(name, data) {
+    for (const view of [sidebar, standaloneWindow]) {
+      if (view && typeof view.postMessage === 'function') {
+        view.postMessage(name, data);
+      }
+    }
+  }
+
   function loadStoredServers() {
     try {
       const serversJson = preferences.get('jellyfin_servers');
@@ -110,9 +123,7 @@ function createServerSessionStore({ preferences, sidebar, log }) {
 
       log(`Removed server: ${serverId}`);
 
-      if (sidebar && sidebar.postMessage) {
-        sidebar.postMessage('servers-updated', { servers, activeServerId: getActiveServerId() });
-      }
+      notifyViews('servers-updated', { servers, activeServerId: getActiveServerId() });
     } catch (error) {
       log(`Error removing server: ${error.message}`);
     }
@@ -139,13 +150,7 @@ function createServerSessionStore({ preferences, sidebar, log }) {
       setActiveServerId(serverId);
       log(`Switched active server to: ${server.serverName}`);
 
-      if (sidebar && sidebar.postMessage) {
-        sidebar.postMessage('server-switched', {
-          server,
-          servers,
-          activeServerId: serverId,
-        });
-      }
+      notifyViews('server-switched', { server, servers, activeServerId: serverId });
     }
   }
 
@@ -159,13 +164,11 @@ function createServerSessionStore({ preferences, sidebar, log }) {
       });
 
       if (server) {
-        if (sidebar && sidebar.postMessage) {
-          sidebar.postMessage('session-available', {
-            serverUrl: server.serverUrl,
-            accessToken: server.accessToken,
-            serverId: server.id,
-          });
-        }
+        notifyViews('session-available', {
+          serverUrl: server.serverUrl,
+          accessToken: server.accessToken,
+          serverId: server.id,
+        });
       }
     } catch (error) {
       log(`Error storing Jellyfin session: ${error.message}`);
@@ -178,9 +181,7 @@ function createServerSessionStore({ preferences, sidebar, log }) {
       saveStoredServers([]);
       setActiveServerId(null);
 
-      if (sidebar && sidebar.postMessage) {
-        sidebar.postMessage('session-cleared', {});
-      }
+      notifyViews('session-cleared', {});
     } catch (error) {
       log(`Error clearing Jellyfin session: ${error.message}`);
     }

--- a/src/lib/server-session-store.js
+++ b/src/lib/server-session-store.js
@@ -25,11 +25,24 @@ function createServerSessionStore({ preferences, sidebar, standaloneWindow, log 
       // Sessions taken from a played URL have no userId until the sidebar
       // connects and reads /Users/Me, so requiring one here deleted them on the
       // very next read and auto-login from URLs never survived.
-      const validServers = servers.filter(
+      const usableServers = servers.filter(
         (server) => server && server.serverUrl && server.accessToken
       );
+
+      // Drop an unverified URL session for a server that is also signed in:
+      // the account entry supersedes it, and keeping both shows the server
+      // twice in the list.
+      const signedInUrls = new Set(
+        usableServers
+          .filter((server) => server.userId)
+          .map((server) => server.serverUrl.replace(/\/$/, ''))
+      );
+      const validServers = usableServers.filter(
+        (server) => server.userId || !signedInUrls.has(server.serverUrl.replace(/\/$/, ''))
+      );
+
       if (validServers.length !== servers.length) {
-        log(`Cleaned ${servers.length - validServers.length} incomplete server entries`);
+        log(`Cleaned ${servers.length - validServers.length} redundant server entries`);
         saveStoredServers(validServers);
       }
       return validServers;
@@ -156,6 +169,26 @@ function createServerSessionStore({ preferences, sidebar, standaloneWindow, log 
 
   function storeJellyfinSession(serverBase, apiKey) {
     try {
+      const normalizedUrl = String(serverBase || '').replace(/\/$/, '');
+
+      // If this server is already signed in, its account credentials are the
+      // better ones and storing the URL's api_key next to them would leave two
+      // entries for the same server in the list.
+      const signedIn = loadStoredServers().find(
+        (server) => server.userId && server.serverUrl.replace(/\/$/, '') === normalizedUrl
+      );
+      if (signedIn) {
+        log(
+          `Server ${normalizedUrl} is already signed in as ${signedIn.username || signedIn.userId}`
+        );
+        notifyViews('session-available', {
+          serverUrl: signedIn.serverUrl,
+          accessToken: signedIn.accessToken,
+          serverId: signedIn.id,
+        });
+        return;
+      }
+
       log(`Storing Jellyfin session data for: ${serverBase}`);
 
       const server = addOrUpdateServer({

--- a/src/lib/server-session-store.js
+++ b/src/lib/server-session-store.js
@@ -8,9 +8,15 @@ function createServerSessionStore({ preferences, sidebar, log }) {
       const servers = typeof serversJson === 'string' ? JSON.parse(serversJson) : serversJson;
       if (!Array.isArray(servers)) return [];
 
-      const validServers = servers.filter((server) => server.userId);
+      // A server is usable as long as it has somewhere to connect and a token.
+      // Sessions taken from a played URL have no userId until the sidebar
+      // connects and reads /Users/Me, so requiring one here deleted them on the
+      // very next read and auto-login from URLs never survived.
+      const validServers = servers.filter(
+        (server) => server && server.serverUrl && server.accessToken
+      );
       if (validServers.length !== servers.length) {
-        log(`Cleaned ${servers.length - validServers.length} ghost server entries without userId`);
+        log(`Cleaned ${servers.length - validServers.length} incomplete server entries`);
         saveStoredServers(validServers);
       }
       return validServers;
@@ -44,12 +50,21 @@ function createServerSessionStore({ preferences, sidebar, log }) {
       const servers = loadStoredServers();
       const normalizedUrl = serverData.serverUrl.replace(/\/$/, '');
 
-      const existingIndex = servers.findIndex(
-        (server) =>
-          server.serverUrl.replace(/\/$/, '') === normalizedUrl &&
-          ((serverData.userId && server.userId === serverData.userId) ||
-            (!serverData.userId && !server.userId))
-      );
+      const isSameUrl = (server) => server.serverUrl.replace(/\/$/, '') === normalizedUrl;
+
+      // Match the same user on the same server. Failing that, a known user
+      // takes over the entry left by a URL session on that server (it is the
+      // same credential being identified), rather than adding a duplicate.
+      // A URL session never claims an entry that already belongs to a user.
+      let existingIndex = -1;
+      if (serverData.userId) {
+        existingIndex = servers.findIndex(
+          (server) => isSameUrl(server) && server.userId === serverData.userId
+        );
+      }
+      if (existingIndex < 0) {
+        existingIndex = servers.findIndex((server) => isSameUrl(server) && !server.userId);
+      }
 
       const serverEntry = {
         id: existingIndex >= 0 ? servers[existingIndex].id : `srv-${Date.now()}`,

--- a/src/ui/sidebar/lib/auth-server-methods.js
+++ b/src/ui/sidebar/lib/auth-server-methods.js
@@ -612,7 +612,13 @@ window.createSidebarAuthServerMethods = function createSidebarAuthServerMethods(
         return;
       }
 
-      const normalizedUrl = this.normalizeServerUrl(serverUrl);
+      let normalizedUrl;
+      try {
+        normalizedUrl = this.normalizeServerUrl(serverUrl);
+      } catch (error) {
+        errorEl.textContent = error.message || 'Invalid server URL';
+        return;
+      }
       debugLog('Normalized URL: ' + normalizedUrl);
 
       try {

--- a/src/ui/sidebar/lib/auth-server-methods.js
+++ b/src/ui/sidebar/lib/auth-server-methods.js
@@ -47,7 +47,9 @@ window.createSidebarAuthServerMethods = function createSidebarAuthServerMethods(
       this.renderServerList();
 
       if (!this.initialAutoConnectDone && !this.currentServer) {
-        const validServers = this.servers.filter((server) => server.userId);
+        // A userId is not required: a session captured from a played URL only
+        // gains one once connectToServer has read /Users/Me.
+        const validServers = this.servers.filter((server) => server.accessToken);
         if (validServers.length > 0) {
           const activeServer =
             validServers.find((server) => server.id === this.activeServerId) || validServers[0];
@@ -62,7 +64,7 @@ window.createSidebarAuthServerMethods = function createSidebarAuthServerMethods(
     renderServerList() {
       const listEl = document.getElementById('savedServerList');
 
-      const validServers = this.servers.filter((server) => server.userId);
+      const validServers = this.servers.filter((server) => server.accessToken);
 
       if (validServers.length === 0) {
         listEl.style.display = 'none';

--- a/src/ui/sidebar/lib/auth-server-methods.js
+++ b/src/ui/sidebar/lib/auth-server-methods.js
@@ -52,8 +52,10 @@ window.createSidebarAuthServerMethods = function createSidebarAuthServerMethods(
           const activeServer =
             validServers.find((server) => server.id === this.activeServerId) || validServers[0];
           this.connectToServer(activeServer);
+          // Only an attempted connection counts as done. An empty list simply
+          // means the plugin has not sent the servers yet.
+          this.initialAutoConnectDone = true;
         }
-        this.initialAutoConnectDone = true;
       }
     },
 

--- a/src/ui/sidebar/lib/auth-server-methods.js
+++ b/src/ui/sidebar/lib/auth-server-methods.js
@@ -500,6 +500,15 @@ window.createSidebarAuthServerMethods = function createSidebarAuthServerMethods(
     },
 
     async authenticateWithQuickConnect() {
+      // The poll that triggers this may already have been cancelled, which
+      // clears both values — without this the request would go to "null/Users/
+      // AuthenticateWithQuickConnect" and report a login failure the user
+      // never attempted.
+      if (!this.qcServerUrl || !this.qcSecret) {
+        debugLog('Quick Connect was cancelled before authentication, ignoring');
+        return;
+      }
+
       try {
         const httpClient = this.getHttpClient();
         const response = await httpClient.post(

--- a/src/ui/sidebar/lib/auth-server-methods.js
+++ b/src/ui/sidebar/lib/auth-server-methods.js
@@ -309,17 +309,6 @@ window.createSidebarAuthServerMethods = function createSidebarAuthServerMethods(
       this.clearLoginForm();
     },
 
-    logout() {
-      debugLog('Logging out user');
-      this.currentUser = null;
-      this.currentServer = null;
-      this.updateServerStatus('Not connected');
-      this.clearAllMediaContent();
-      this.hideMainContent();
-      this.showConnectButton();
-      this.clearLoginForm();
-    },
-
     updateServerStatus(message, status = '') {
       const statusEl = document.getElementById('serverStatus');
       statusEl.textContent = message;

--- a/src/ui/sidebar/lib/auth-server-methods.js
+++ b/src/ui/sidebar/lib/auth-server-methods.js
@@ -145,7 +145,9 @@ window.createSidebarAuthServerMethods = function createSidebarAuthServerMethods(
               url: serverData.serverUrl,
               userId: userResponse.data.Id,
               accessToken: serverData.accessToken,
-              serverId: serverData.id,
+              // Stored server entries carry "id"; session payloads sent to the
+              // webview carry "serverId". Both reach this function.
+              serverId: serverData.id || serverData.serverId,
             };
 
             this.currentUser = userResponse.data;

--- a/src/ui/sidebar/lib/media-methods.js
+++ b/src/ui/sidebar/lib/media-methods.js
@@ -207,13 +207,14 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
 
       try {
         const params = new URLSearchParams({
+          userId: this.currentUser.Id,
           Limit: 10,
           MediaTypes: 'Video',
           Fields:
             'Overview,UserData,RunTimeTicks,SeriesName,ProductionYear,ParentIndexNumber,IndexNumber,SeriesId,ImageTags,BackdropImageTags',
         });
 
-        const fullUrl = `${this.currentServer.url}/Users/${this.currentUser.Id}/Items/Resume?${params.toString()}`;
+        const fullUrl = `${this.currentServer.url}/UserItems/Resume?${params.toString()}`;
 
         const response = await this.getHttpClient().get(fullUrl, {
           headers: {
@@ -305,7 +306,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
           params.append('Genres', genreValue);
         }
 
-        const fullUrl = `${this.currentServer.url}/Users/${this.currentUser.Id}/Items?${params.toString()}`;
+        const fullUrl = `${this.currentServer.url}/Items?${params.toString()}`;
 
         const response = await this.getHttpClient().get(fullUrl, {
           headers: {
@@ -360,7 +361,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
           params.append('Genres', genreValue);
         }
 
-        const fullUrl = `${this.currentServer.url}/Users/${this.currentUser.Id}/Items?${params.toString()}`;
+        const fullUrl = `${this.currentServer.url}/Items?${params.toString()}`;
 
         const response = await this.getHttpClient().get(fullUrl, {
           headers: {
@@ -1025,7 +1026,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
         params.append('Genres', genreValue);
       }
 
-      const fullUrl = `${this.currentServer.url}/Users/${this.currentUser.Id}/Items?${params.toString()}`;
+      const fullUrl = `${this.currentServer.url}/Items?${params.toString()}`;
 
       const response = await this.getHttpClient().get(fullUrl, {
         headers: {
@@ -1089,7 +1090,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
         params.append('Genres', genreValue);
       }
 
-      const fullUrl = `${this.currentServer.url}/Users/${this.currentUser.Id}/Items?${params.toString()}`;
+      const fullUrl = `${this.currentServer.url}/Items?${params.toString()}`;
 
       const response = await this.getHttpClient().get(fullUrl, {
         headers: {
@@ -1284,7 +1285,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
           Limit: 50,
         });
 
-        const fullUrl = `${this.currentServer.url}/Users/${this.currentUser.Id}/Items?${params.toString()}`;
+        const fullUrl = `${this.currentServer.url}/Items?${params.toString()}`;
 
         const response = await this.getHttpClient().get(fullUrl, {
           headers: {
@@ -1333,7 +1334,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
           IncludeItemTypes: 'Audio',
         });
 
-        const fullUrl = `${this.currentServer.url}/Users/${this.currentUser.Id}/Items?${params.toString()}`;
+        const fullUrl = `${this.currentServer.url}/Items?${params.toString()}`;
 
         const response = await this.getHttpClient().get(fullUrl, {
           headers: {

--- a/src/ui/sidebar/lib/media-methods.js
+++ b/src/ui/sidebar/lib/media-methods.js
@@ -956,19 +956,11 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
           return false;
         }
 
-        const hasValidPath = episode.MediaSources.some((source) => {
-          return source.Path && source.Path.trim() !== '';
-        });
-
-        if (!hasValidPath) {
-          debugLog(`Episode ${episode.Name} has no valid media paths`);
-          return false;
-        }
-
-        if (!episode.Path || episode.Path.trim() === '') {
-          debugLog(`Episode ${episode.Name} has no direct path`);
-          return false;
-        }
+        // Filesystem paths are deliberately not checked: Jellyfin withholds
+        // Path from non-admin accounts, and an episode that is playable by
+        // streaming does not need one. LocationType and MediaSources already
+        // say whether the file exists on the server, which is the same test
+        // the autoplay manager uses.
 
         if (episode.IsFolder === true) {
           debugLog(`Episode ${episode.Name} marked as folder`);

--- a/src/ui/sidebar/lib/media-methods.js
+++ b/src/ui/sidebar/lib/media-methods.js
@@ -527,8 +527,9 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
 
       let subtitle = '';
       if (item.Type === 'Episode' && item.SeriesName) {
-        const season = item.ParentIndexNumber || '?';
-        const episode = item.IndexNumber || '?';
+        // ?? not ||: specials are season 0, and episode 0 exists too
+        const season = item.ParentIndexNumber ?? '?';
+        const episode = item.IndexNumber ?? '?';
         subtitle = `${item.SeriesName} - S${season}E${episode}`;
       } else if (item.Type === 'Series') {
         subtitle = 'TV Series';
@@ -812,7 +813,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
             episodeEl.dataset.episodeId = episode.Id;
             episodeEl.dataset.available = isAvailable.toString();
 
-            const episodeNum = episode.IndexNumber || '?';
+            const episodeNum = episode.IndexNumber ?? '?';
             const title = episode.Name || `Episode ${episodeNum}`;
             const duration = this.formatRuntime(episode.RunTimeTicks);
 

--- a/src/ui/sidebar/lib/media-methods.js
+++ b/src/ui/sidebar/lib/media-methods.js
@@ -66,9 +66,11 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
     },
 
     hideMainContent() {
+      // Both helpers return to the media list by default; here the whole
+      // content area is going away, so they must not show it again.
+      this.hideEpisodeSelection(false);
+      this.hideAlbumTracks(false);
       document.getElementById('mainContent').style.display = 'none';
-      this.hideEpisodeSelection();
-      this.hideAlbumTracks();
     },
 
     /**
@@ -882,9 +884,11 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
       }
     },
 
-    hideEpisodeSelection() {
+    hideEpisodeSelection(returnToMain = true) {
       document.getElementById('episodeSection').style.display = 'none';
-      document.getElementById('mainContent').style.display = 'block';
+      if (returnToMain) {
+        document.getElementById('mainContent').style.display = 'block';
+      }
       this.selectedEpisode = null;
       this.selectedSeason = null;
       document.getElementById('playEpisodeBtn').disabled = true;
@@ -1426,9 +1430,11 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
       }
     },
 
-    hideAlbumTracks() {
+    hideAlbumTracks(returnToMain = true) {
       document.getElementById('albumTracksSection').style.display = 'none';
-      document.getElementById('mainContent').style.display = 'block';
+      if (returnToMain) {
+        document.getElementById('mainContent').style.display = 'block';
+      }
       this.selectedAlbum = null;
       this.selectedTrack = null;
       this.albumTracks = [];

--- a/src/ui/sidebar/lib/media-methods.js
+++ b/src/ui/sidebar/lib/media-methods.js
@@ -676,7 +676,11 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
       this.selectedItem = item;
 
       document.querySelectorAll('.media-item').forEach((el) => el.classList.remove('selected'));
-      document.querySelector(`[data-item-id="${item.Id}"]`).classList.add('selected');
+      // The item is not always on screen (e.g. selected from search results)
+      const selectedEl = document.querySelector(`[data-item-id="${item.Id}"]`);
+      if (selectedEl) {
+        selectedEl.classList.add('selected');
+      }
 
       if (item.Type === 'Series') {
         debugLog('Item is a Series, showing episode selection');

--- a/src/ui/sidebar/lib/media-methods.js
+++ b/src/ui/sidebar/lib/media-methods.js
@@ -1476,18 +1476,8 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
             this.hideEpisodeSelection();
           }
         } else {
-          debugLog('iina.postMessage not available, trying global object');
-          if (typeof window !== 'undefined' && window.jellyfinPlugin) {
-            debugLog('Using window.jellyfinPlugin for communication');
-            if (window.jellyfinPlugin.playMedia) {
-              window.jellyfinPlugin.playMedia(streamUrl, item.Name || 'Unknown Title');
-            } else {
-              debugLog('window.jellyfinPlugin.playMedia not available');
-            }
-          } else {
-            debugLog('No communication method available, opening in new window');
-            window.open(streamUrl, '_blank');
-          }
+          debugLog('iina.postMessage not available, opening in a new window');
+          window.open(streamUrl, '_blank');
         }
       } catch (error) {
         debugLog('Error playing media:', error);

--- a/src/ui/sidebar/lib/media-methods.js
+++ b/src/ui/sidebar/lib/media-methods.js
@@ -716,8 +716,13 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
           this.selectMediaItem(response.data);
         }
       } catch (error) {
+        // The webview has no core API — iina here only exposes postMessage and
+        // onMessage — so report failures in the UI, not through an OSD.
         debugLog('Error getting item details:', error);
-        iina.core.osd('Failed to get item details');
+        const searchResults = document.getElementById('searchResults');
+        if (searchResults) {
+          searchResults.innerHTML = '<div class="error">Failed to open item</div>';
+        }
       }
     },
 
@@ -934,12 +939,8 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
 
         debugLog('Successfully sent open-external-url message to IINA');
       } catch (error) {
-        debugLog('Error in openInJellyfin:', error);
-
-        const errorMessage = `Failed to open Jellyfin page: ${error.message}`;
-        if (typeof iina !== 'undefined' && iina.core && iina.core.osd) {
-          iina.core.osd(errorMessage);
-        }
+        // No core API in the webview; the plugin shows the OSD for this action
+        debugLog(`Failed to open Jellyfin page: ${error.message}`);
       }
     },
 

--- a/src/ui/sidebar/lib/media-methods.js
+++ b/src/ui/sidebar/lib/media-methods.js
@@ -969,11 +969,6 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
           return false;
         }
 
-        if (episode.CanDownload === false) {
-          debugLog(`Episode ${episode.Name} marked as not downloadable`);
-          return false;
-        }
-
         if (episode.IsFolder === true) {
           debugLog(`Episode ${episode.Name} marked as folder`);
           return false;
@@ -1443,9 +1438,16 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
       document.getElementById('openAlbumInJellyfinBtn').disabled = true;
     },
 
+    /**
+     * Build a direct-play URL. The streaming routes are what Jellyfin's own
+     * clients use; /Items/{id}/Download additionally requires the account to
+     * have media download permission, which browsing does not.
+     * static=true asks for the original file without transcoding.
+     */
     buildStreamUrl(item) {
       if (!this.currentServer || !item || !item.Id) return null;
-      return `${this.currentServer.url}/Items/${item.Id}/Download?api_key=${this.currentServer.accessToken}`;
+      const route = item.Type === 'Audio' ? 'Audio' : 'Videos';
+      return `${this.currentServer.url}/${route}/${item.Id}/stream?static=true&api_key=${this.currentServer.accessToken}`;
     },
 
     async playMedia(item) {

--- a/src/ui/sidebar/sidebar.js
+++ b/src/ui/sidebar/sidebar.js
@@ -296,12 +296,19 @@ class JellyfinSidebar {
       this.hideAlbumTracks();
     });
 
-    // Enter key handling
-    document.getElementById('password').addEventListener('keypress', (e) => {
-      if (e.key === 'Enter') {
-        this.login();
-      }
-    });
+    // Enter submits from any field of the form it belongs to
+    const submitOnEnter = (id, submit) => {
+      const field = document.getElementById(id);
+      if (!field) return;
+      field.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') {
+          submit();
+        }
+      });
+    };
+
+    ['serverUrl', 'username', 'password'].forEach((id) => submitOnEnter(id, () => this.login()));
+    submitOnEnter('qcServerUrl', () => this.startQuickConnect());
   }
 
   setupTabNavigation() {
@@ -398,20 +405,24 @@ class JellyfinSidebar {
 Object.assign(JellyfinSidebar.prototype, window.createSidebarAuthServerMethods(debugLog));
 Object.assign(JellyfinSidebar.prototype, window.createSidebarMediaMethods(debugLog));
 
-// Initialize sidebar when DOM is loaded
-document.addEventListener('DOMContentLoaded', () => {
-  debugLog('DOM loaded, initializing Jellyfin sidebar');
-  window.jellyfinSidebar = new JellyfinSidebar();
-  debugLog('Jellyfin sidebar initialized');
-});
-
 // Expose for main plugin communication
 window.JellyfinSidebar = JellyfinSidebar;
 
-// Also try to initialize immediately if DOM is already loaded
+// Constructing twice would attach a second set of DOM listeners, so make
+// initialization idempotent rather than relying on which branch runs.
+function initJellyfinSidebar() {
+  if (window.jellyfinSidebar) {
+    debugLog('Jellyfin sidebar already initialized');
+    return;
+  }
+  window.jellyfinSidebar = new JellyfinSidebar();
+  debugLog('Jellyfin sidebar initialized');
+}
+
 if (document.readyState === 'loading') {
   debugLog('DOM still loading, waiting for DOMContentLoaded');
+  document.addEventListener('DOMContentLoaded', initJellyfinSidebar);
 } else {
   debugLog('DOM already loaded, initializing immediately');
-  window.jellyfinSidebar = new JellyfinSidebar();
+  initJellyfinSidebar();
 }

--- a/src/ui/sidebar/sidebar.js
+++ b/src/ui/sidebar/sidebar.js
@@ -9,6 +9,17 @@
  */
 const MAX_DEBUG_LOG_LENGTH = 600;
 
+// Credentials travel in URLs (api_key=...) and in the MediaBrowser
+// Authorization header (Token="..."). Strip them from anything we log.
+const SECRET_QUERY_PARAM = /([?&](?:api_key|apikey|api-key|x-emby-token)=)[^&\s"']+/gi;
+const SECRET_TOKEN_FIELD = /((?:token|accesstoken|api_key)"?\s*[:=]\s*"?)[A-Za-z0-9._-]{8,}/gi;
+
+function redactSecrets(value) {
+  return String(value)
+    .replace(SECRET_QUERY_PARAM, '$1[redacted]')
+    .replace(SECRET_TOKEN_FIELD, '$1[redacted]');
+}
+
 function truncateDebugText(value, maxLength = MAX_DEBUG_LOG_LENGTH) {
   if (value.length <= maxLength) {
     return value;
@@ -73,7 +84,7 @@ function serializeDebugArg(arg) {
 
 function debugLog(...parts) {
   if (iina?.preferences?.get?.('debug_logging')) {
-    console.log(`DEBUG: ${parts.map(serializeDebugArg).join(' | ')}`);
+    console.log(`DEBUG: ${redactSecrets(parts.map(serializeDebugArg).join(' | '))}`);
   }
 }
 


### PR DESCRIPTION
### Playback
- Stream media (`/Videos|/Audio/{id}/stream`) instead of `/Items/{id}/Download`,
  which required download permission users don't need to watch. `parseJellyfinUrl`
  accepts the streaming routes, or tracking, resume, titles and subtitles would
  have stopped recognising what is playing.
- Play All queues the whole album again: `core.open()` defers its mpv load for
  network URLs and that load replaces the playlist, so the rest is appended once
  the first track has loaded.
- Rewinding to 0 and stopping now reports 0 instead of the old resume position,
  while a file closed before playback starts no longer clears its resume point.
- Autoplay continues across gaps in episode numbering, and specials are season 0.

### Browser
- The browser opens again after a player window has been closed (`sidebar.show()`
  succeeded silently on an invisible window).
- Standalone window: message handlers work, geometry and title apply
  (`setFrame`/`setProperty` were being called with the wrong shapes).
- Sessions captured from a played URL survive, without duplicating a server that
  is already signed in.
- Disconnect actually clears the stored credentials.
- Episode availability no longer depends on filesystem paths Jellyfin hides from
  non-admin users; same for external subtitle downloads.
- Reverse proxy subpaths (`https://host/jellyfin`) are kept in the server base.

### Other
- Credentials redacted from debug logs.
- `Cmd+Shift+J` bound correctly — it was registering as `Shift+J` and taking over
  IINA's cycle-subtitles-backward shortcut.
- Embedded subtitle downloads dropped: the URL they used 404s, and extraction is
  slow. External subtitles only, stated in the preferences and help text.
- Removed subscriptions to mpv events that never fire, the `logout()` and
  `global.playMedia` dead paths, and preferences nothing reads.