### PR TITLE
fix: support Jellyfin 12 authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ An comprehensive IINA plugin that provides Jellyfin media server integration, in
 
 The plugin automatically detects and downloads subtitles when you open Jellyfin URLs:
 
-1. Copy a Jellyfin media URL (e.g., from a Jellyfin download link containing `/Items/` and `api_key=`)
+1. Copy a Jellyfin media URL (e.g., from a Jellyfin download link containing `/Items/` and `ApiKey=`)
 2. Open the URL in IINA using File → Open URL
 3. Subtitles will be downloaded automatically based on your language preferences
 4. Manually download subtitles anytime using: Menu → "Download Jellyfin Subtitles" (or `Cmd+Shift+D`)
@@ -68,7 +68,7 @@ Open the browser sidebar using: View menu → "Show Jellyfin Browser" or press `
 
 **Option 1: Automatic Login via URL (Recommended)**
 
-1. Copy any Jellyfin media download URL containing an API key from your server (e.g., `http://server:8096/Items/{ItemId}/Download?api_key={key}`)
+1. Copy any Jellyfin media download URL containing an API key from your server (e.g., `http://server:8096/Items/{ItemId}/Download?ApiKey={key}`)
 2. Open the URL in IINA using File → Open URL
 3. The plugin automatically extracts and stores your server credentials
 4. When you open the sidebar, it will auto-connect to your server
@@ -153,8 +153,8 @@ Click the "Filter/Sort" button in the Movies or TV Series tab header to toggle t
 
 The plugin automatically detects and processes Jellyfin URLs in these formats:
 
-- Download URLs: `http://server:port/Items/{ItemId}/Download?api_key={key}` _(automatically stores credentials for sidebar login)_
-- URLs containing `/Items/` and `api_key=` _(automatically stores credentials for sidebar login)_
+- Download URLs: `http://server:port/Items/{ItemId}/Download?ApiKey={key}` _(automatically stores credentials for sidebar login)_
+- URLs containing `/Items/` and `ApiKey=` _(automatically stores credentials for sidebar login)_
 - URLs containing "jellyfin", "/Audio/", or "/Videos/"
 
 **Note**: URLs with API keys will automatically store authentication data for the sidebar browser, eliminating the need for manual login on first use.

--- a/help.html
+++ b/help.html
@@ -137,7 +137,7 @@
       <ul>
         <li>
           Jellyfin download URLs containing <code>/Items/</code> and
-          <code>api_key=</code>
+          <code>ApiKey=</code>
         </li>
         <li>URLs containing "jellyfin", "/Audio/", or "/Videos/"</li>
       </ul>

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "Mateusz Hajder",
   "type": "module",
   "scripts": {
+    "test": "node --test tests/*.test.js",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "lint": "eslint src/",

--- a/pref.html
+++ b/pref.html
@@ -93,7 +93,7 @@
       </label>
       <p class="small secondary pref-help">
         Replace the default filename with the actual movie/show title from Jellyfin. Shows proper
-        titles instead of generic "Download?api_key=..." names.
+        titles instead of generic "Download?ApiKey=..." names.
       </p>
     </div>
 

--- a/src/lib/autoplay-manager.js
+++ b/src/lib/autoplay-manager.js
@@ -24,7 +24,7 @@ function createAutoplayManager({
       ].join('&');
 
       const response = await http.get(
-        `${serverBase}/Shows/${seriesId}/Episodes?${queryParams}&api_key=${apiKey}`,
+        `${serverBase}/Shows/${seriesId}/Episodes?${queryParams}&ApiKey=${apiKey}`,
         {
           headers: buildJellyfinHeaders(apiKey, {
             Accept: 'application/json',
@@ -52,7 +52,7 @@ function createAutoplayManager({
         name: episode.Name,
         indexNumber: Number(episode.IndexNumber) || 0,
         duration: episode.RunTimeTicks,
-        playUrl: `${serverBase}/Videos/${episode.Id}/stream?static=true&api_key=${apiKey}`,
+        playUrl: `${serverBase}/Videos/${episode.Id}/stream?static=true&ApiKey=${apiKey}`,
       }));
 
       episodes.sort((left, right) => left.indexNumber - right.indexNumber);
@@ -128,7 +128,7 @@ function createAutoplayManager({
       log('No next episode in current season, checking next season...');
 
       const seasonsResponse = await http.get(
-        `${serverBase}/Shows/${seriesId}/Seasons?api_key=${apiKey}`,
+        `${serverBase}/Shows/${seriesId}/Seasons?ApiKey=${apiKey}`,
         {
           headers: buildJellyfinHeaders(apiKey, { Accept: 'application/json' }),
         }

--- a/src/lib/debug-log.js
+++ b/src/lib/debug-log.js
@@ -3,7 +3,7 @@
 const MAX_LOG_LENGTH = 600;
 const MAX_KEYS = 8;
 
-// Credentials travel in URLs (api_key=...) and in the MediaBrowser
+// Credentials travel in URLs (ApiKey=...) and in the MediaBrowser
 // Authorization header (Token="..."). Strip them from anything we log.
 const SECRET_QUERY_PARAM = /([?&](?:api_key|apikey|api-key|x-emby-token)=)[^&\s"']+/gi;
 const SECRET_TOKEN_FIELD = /((?:token|accesstoken|api_key)"?\s*[:=]\s*"?)[A-Za-z0-9._-]{8,}/gi;

--- a/src/lib/jellyfin-api.js
+++ b/src/lib/jellyfin-api.js
@@ -147,7 +147,7 @@ function createJellyfinApi({ http, preferences, log }) {
 
   async function fetchPlaybackInfo(serverBase, itemId, apiKey) {
     try {
-      const playbackUrl = `${serverBase}/Items/${itemId}/PlaybackInfo?api_key=${apiKey}`;
+      const playbackUrl = `${serverBase}/Items/${itemId}/PlaybackInfo?ApiKey=${apiKey}`;
       log(`Fetching playback info from: ${playbackUrl}`);
 
       const response = await http.get(playbackUrl, {
@@ -181,7 +181,7 @@ function createJellyfinApi({ http, preferences, log }) {
 
   async function fetchItemMetadata(serverBase, itemId, apiKey) {
     try {
-      const metadataUrl = `${serverBase}/Items/${itemId}?api_key=${apiKey}`;
+      const metadataUrl = `${serverBase}/Items/${itemId}?ApiKey=${apiKey}`;
       log(`Fetching item metadata from: ${metadataUrl}`);
 
       const response = await http.get(metadataUrl, {

--- a/src/lib/media-actions.js
+++ b/src/lib/media-actions.js
@@ -96,7 +96,7 @@ function createMediaActionsManager({
     try {
       const extension = subtitleExtensionForCodec(codec);
 
-      const subtitleUrl = `${serverBase}/Videos/${itemId}/${mediaSourceId || itemId}/Subtitles/${streamIndex}/stream.${extension}?api_key=${apiKey}`;
+      const subtitleUrl = `${serverBase}/Videos/${itemId}/${mediaSourceId || itemId}/Subtitles/${streamIndex}/stream.${extension}?ApiKey=${apiKey}`;
 
       // Everything lands in one @tmp directory, so the name has to identify the
       // item and the track. Server-side names like "English.srt" repeat across

--- a/src/lib/playback-tracking.js
+++ b/src/lib/playback-tracking.js
@@ -140,7 +140,7 @@ function createPlaybackTrackingManager({
         return false;
       }
 
-      const url = `${serverBase}/Sessions/Playing?api_key=${apiKey}`;
+      const url = `${serverBase}/Sessions/Playing?ApiKey=${apiKey}`;
       log(`Reporting playback start for item: ${itemId}`);
 
       const response = await http.post(url, {
@@ -188,7 +188,7 @@ function createPlaybackTrackingManager({
       }
 
       const positionTicks = secondsToTicks(positionSeconds);
-      const url = `${serverBase}/Sessions/Playing/Progress?api_key=${apiKey}`;
+      const url = `${serverBase}/Sessions/Playing/Progress?ApiKey=${apiKey}`;
 
       const response = await http.post(url, {
         headers: buildJellyfinHeaders(apiKey, {
@@ -235,7 +235,7 @@ function createPlaybackTrackingManager({
       }
 
       const positionTicks = secondsToTicks(positionSeconds);
-      const url = `${serverBase}/Sessions/Playing/Stopped?api_key=${apiKey}`;
+      const url = `${serverBase}/Sessions/Playing/Stopped?ApiKey=${apiKey}`;
 
       log(`Reporting playback stop: position=${positionSeconds}s (${positionTicks} ticks)`);
 
@@ -274,7 +274,7 @@ function createPlaybackTrackingManager({
         return false;
       }
 
-      const url = `${serverBase}/UserPlayedItems/${itemId}?api_key=${apiKey}`;
+      const url = `${serverBase}/UserPlayedItems/${itemId}?ApiKey=${apiKey}`;
       log(`Marking item as watched: ${itemId}`);
 
       const response = await http.post(url, {

--- a/src/ui/sidebar/lib/auth-server-methods.js
+++ b/src/ui/sidebar/lib/auth-server-methods.js
@@ -128,14 +128,14 @@ window.createSidebarAuthServerMethods = function createSidebarAuthServerMethods(
 
         const response = await this.getHttpClient().get(`${serverData.serverUrl}/System/Info`, {
           headers: {
-            'X-Emby-Token': serverData.accessToken,
+            Authorization: this.buildAuthorizationHeader(serverData.accessToken),
           },
         });
 
         if (response.status === 200 && response.data) {
           const userResponse = await this.getHttpClient().get(`${serverData.serverUrl}/Users/Me`, {
             headers: {
-              'X-Emby-Token': serverData.accessToken,
+              Authorization: this.buildAuthorizationHeader(serverData.accessToken),
             },
           });
 

--- a/src/ui/sidebar/lib/media-methods.js
+++ b/src/ui/sidebar/lib/media-methods.js
@@ -41,7 +41,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
 
         const response = await this.getHttpClient().get(fullUrl, {
           headers: {
-            'X-Emby-Token': this.currentServer.accessToken,
+            Authorization: this.buildAuthorizationHeader(this.currentServer.accessToken),
           },
         });
 
@@ -170,7 +170,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
 
         const response = await this.getHttpClient().get(fullUrl, {
           headers: {
-            'X-Emby-Token': this.currentServer.accessToken,
+            Authorization: this.buildAuthorizationHeader(this.currentServer.accessToken),
           },
         });
 
@@ -220,7 +220,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
 
         const response = await this.getHttpClient().get(fullUrl, {
           headers: {
-            'X-Emby-Token': this.currentServer.accessToken,
+            Authorization: this.buildAuthorizationHeader(this.currentServer.accessToken),
           },
         });
 
@@ -257,7 +257,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
 
         const response = await this.getHttpClient().get(fullUrl, {
           headers: {
-            'X-Emby-Token': this.currentServer.accessToken,
+            Authorization: this.buildAuthorizationHeader(this.currentServer.accessToken),
           },
         });
 
@@ -312,7 +312,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
 
         const response = await this.getHttpClient().get(fullUrl, {
           headers: {
-            'X-Emby-Token': this.currentServer.accessToken,
+            Authorization: this.buildAuthorizationHeader(this.currentServer.accessToken),
           },
         });
 
@@ -367,7 +367,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
 
         const response = await this.getHttpClient().get(fullUrl, {
           headers: {
-            'X-Emby-Token': this.currentServer.accessToken,
+            Authorization: this.buildAuthorizationHeader(this.currentServer.accessToken),
           },
         });
 
@@ -431,7 +431,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
 
         const response = await this.getHttpClient().get(fullUrl, {
           headers: {
-            'X-Emby-Token': this.currentServer.accessToken,
+            Authorization: this.buildAuthorizationHeader(this.currentServer.accessToken),
           },
         });
 
@@ -485,21 +485,21 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
 
       if (item.Type === 'Episode') {
         if (item.ImageTags && item.ImageTags.Primary) {
-          return `${base}/Items/${item.Id}/Images/Primary?maxWidth=${maxWidth}&quality=90&api_key=${token}`;
+          return `${base}/Items/${item.Id}/Images/Primary?maxWidth=${maxWidth}&quality=90&ApiKey=${token}`;
         }
         if (item.SeriesId) {
-          return `${base}/Items/${item.SeriesId}/Images/Thumb?maxWidth=${maxWidth}&quality=90&api_key=${token}`;
+          return `${base}/Items/${item.SeriesId}/Images/Thumb?maxWidth=${maxWidth}&quality=90&ApiKey=${token}`;
         }
       }
 
       if (item.ImageTags && item.ImageTags.Thumb) {
-        return `${base}/Items/${item.Id}/Images/Thumb?maxWidth=${maxWidth}&quality=90&api_key=${token}`;
+        return `${base}/Items/${item.Id}/Images/Thumb?maxWidth=${maxWidth}&quality=90&ApiKey=${token}`;
       }
       if (item.ImageTags && item.ImageTags.Primary) {
-        return `${base}/Items/${item.Id}/Images/Primary?maxWidth=${maxWidth}&quality=90&api_key=${token}`;
+        return `${base}/Items/${item.Id}/Images/Primary?maxWidth=${maxWidth}&quality=90&ApiKey=${token}`;
       }
       if (item.BackdropImageTags && item.BackdropImageTags.length > 0) {
-        return `${base}/Items/${item.Id}/Images/Backdrop?maxWidth=${maxWidth * 2}&quality=90&api_key=${token}`;
+        return `${base}/Items/${item.Id}/Images/Backdrop?maxWidth=${maxWidth * 2}&quality=90&ApiKey=${token}`;
       }
       return null;
     },
@@ -609,11 +609,11 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
         const base = this.currentServer.url;
         const token = this.currentServer.accessToken;
         if (hint.ThumbImageTag && hint.ThumbImageItemId) {
-          thumbUrl = `${base}/Items/${hint.ThumbImageItemId}/Images/Thumb?maxWidth=160&quality=90&api_key=${token}`;
+          thumbUrl = `${base}/Items/${hint.ThumbImageItemId}/Images/Thumb?maxWidth=160&quality=90&ApiKey=${token}`;
         } else if (hint.PrimaryImageTag) {
-          thumbUrl = `${base}/Items/${hint.ItemId}/Images/Primary?maxWidth=160&quality=90&api_key=${token}`;
+          thumbUrl = `${base}/Items/${hint.ItemId}/Images/Primary?maxWidth=160&quality=90&ApiKey=${token}`;
         } else if (hint.BackdropImageTag && hint.BackdropImageItemId) {
-          thumbUrl = `${base}/Items/${hint.BackdropImageItemId}/Images/Backdrop?maxWidth=320&quality=90&api_key=${token}`;
+          thumbUrl = `${base}/Items/${hint.BackdropImageItemId}/Images/Backdrop?maxWidth=320&quality=90&ApiKey=${token}`;
         }
       }
 
@@ -708,7 +708,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
           `${this.currentServer.url}/Items/${hint.ItemId}?${params.toString()}`,
           {
             headers: {
-              'X-Emby-Token': this.currentServer.accessToken,
+              Authorization: this.buildAuthorizationHeader(this.currentServer.accessToken),
             },
           }
         );
@@ -748,7 +748,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
           `${this.currentServer.url}/Shows/${series.Id}/Seasons?${params.toString()}`,
           {
             headers: {
-              'X-Emby-Token': this.currentServer.accessToken,
+              Authorization: this.buildAuthorizationHeader(this.currentServer.accessToken),
             },
           }
         );
@@ -796,7 +796,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
           `${this.currentServer.url}/Shows/${this.selectedItem.Id}/Episodes?${params.toString()}`,
           {
             headers: {
-              'X-Emby-Token': this.currentServer.accessToken,
+              Authorization: this.buildAuthorizationHeader(this.currentServer.accessToken),
             },
           }
         );
@@ -822,9 +822,9 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
               const base = this.currentServer.url;
               const token = this.currentServer.accessToken;
               if (episode.ImageTags && episode.ImageTags.Primary) {
-                episodeThumbUrl = `${base}/Items/${episode.Id}/Images/Primary?maxWidth=120&quality=90&api_key=${token}`;
+                episodeThumbUrl = `${base}/Items/${episode.Id}/Images/Primary?maxWidth=120&quality=90&ApiKey=${token}`;
               } else if (this.selectedItem && this.selectedItem.Id) {
-                episodeThumbUrl = `${base}/Items/${this.selectedItem.Id}/Images/Thumb?maxWidth=120&quality=90&api_key=${token}`;
+                episodeThumbUrl = `${base}/Items/${this.selectedItem.Id}/Images/Thumb?maxWidth=120&quality=90&ApiKey=${token}`;
               }
             }
 
@@ -1023,7 +1023,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
 
       const response = await this.getHttpClient().get(fullUrl, {
         headers: {
-          'X-Emby-Token': this.currentServer.accessToken,
+          Authorization: this.buildAuthorizationHeader(this.currentServer.accessToken),
         },
       });
 
@@ -1054,7 +1054,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
 
       const response = await this.getHttpClient().get(fullUrl, {
         headers: {
-          'X-Emby-Token': this.currentServer.accessToken,
+          Authorization: this.buildAuthorizationHeader(this.currentServer.accessToken),
         },
       });
 
@@ -1087,7 +1087,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
 
       const response = await this.getHttpClient().get(fullUrl, {
         headers: {
-          'X-Emby-Token': this.currentServer.accessToken,
+          Authorization: this.buildAuthorizationHeader(this.currentServer.accessToken),
         },
       });
 
@@ -1113,7 +1113,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
 
         const response = await this.getHttpClient().get(fullUrl, {
           headers: {
-            'X-Emby-Token': this.currentServer.accessToken,
+            Authorization: this.buildAuthorizationHeader(this.currentServer.accessToken),
           },
         });
 
@@ -1139,13 +1139,13 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
       const token = this.currentServer.accessToken;
 
       if (item.ImageTags && item.ImageTags.Primary) {
-        return `${base}/Items/${item.Id}/Images/Primary?maxWidth=${maxWidth}&quality=90&api_key=${token}`;
+        return `${base}/Items/${item.Id}/Images/Primary?maxWidth=${maxWidth}&quality=90&ApiKey=${token}`;
       }
       if (item.AlbumId) {
-        return `${base}/Items/${item.AlbumId}/Images/Primary?maxWidth=${maxWidth}&quality=90&api_key=${token}`;
+        return `${base}/Items/${item.AlbumId}/Images/Primary?maxWidth=${maxWidth}&quality=90&ApiKey=${token}`;
       }
       if (item.BackdropImageTags && item.BackdropImageTags.length > 0) {
-        return `${base}/Items/${item.Id}/Images/Backdrop?maxWidth=${maxWidth * 2}&quality=90&api_key=${token}`;
+        return `${base}/Items/${item.Id}/Images/Backdrop?maxWidth=${maxWidth * 2}&quality=90&ApiKey=${token}`;
       }
       return null;
     },
@@ -1282,7 +1282,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
 
         const response = await this.getHttpClient().get(fullUrl, {
           headers: {
-            'X-Emby-Token': this.currentServer.accessToken,
+            Authorization: this.buildAuthorizationHeader(this.currentServer.accessToken),
           },
         });
 
@@ -1331,7 +1331,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
 
         const response = await this.getHttpClient().get(fullUrl, {
           headers: {
-            'X-Emby-Token': this.currentServer.accessToken,
+            Authorization: this.buildAuthorizationHeader(this.currentServer.accessToken),
           },
         });
 
@@ -1441,7 +1441,7 @@ window.createSidebarMediaMethods = function createSidebarMediaMethods(debugLog) 
     buildStreamUrl(item) {
       if (!this.currentServer || !item || !item.Id) return null;
       const route = item.Type === 'Audio' ? 'Audio' : 'Videos';
-      return `${this.currentServer.url}/${route}/${item.Id}/stream?static=true&api_key=${this.currentServer.accessToken}`;
+      return `${this.currentServer.url}/${route}/${item.Id}/stream?static=true&ApiKey=${this.currentServer.accessToken}`;
     },
 
     async playMedia(item) {

--- a/src/ui/sidebar/sidebar.js
+++ b/src/ui/sidebar/sidebar.js
@@ -9,7 +9,7 @@
  */
 const MAX_DEBUG_LOG_LENGTH = 600;
 
-// Credentials travel in URLs (api_key=...) and in the MediaBrowser
+// Credentials travel in URLs (ApiKey=...) and in the MediaBrowser
 // Authorization header (Token="..."). Strip them from anything we log.
 const SECRET_QUERY_PARAM = /([?&](?:api_key|apikey|api-key|x-emby-token)=)[^&\s"']+/gi;
 const SECRET_TOKEN_FIELD = /((?:token|accesstoken|api_key)"?\s*[:=]\s*"?)[A-Za-z0-9._-]{8,}/gi;

--- a/tests/jellyfin-12-auth.test.js
+++ b/tests/jellyfin-12-auth.test.js
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import vm from 'node:vm';
+
+function loadSidebarMethods(file, factoryName, globals = {}) {
+  const context = vm.createContext({ window: {}, ...globals });
+  vm.runInContext(readFileSync(file, 'utf8'), context);
+  return context.window[factoryName](() => {});
+}
+
+test('saved sessions reconnect with Jellyfin 12 authorization', async () => {
+  const requests = [];
+  const methods = loadSidebarMethods(
+    'src/ui/sidebar/lib/auth-server-methods.js',
+    'createSidebarAuthServerMethods'
+  );
+  const client = {
+    ...methods,
+    clientIdentity: {
+      clientName: 'IINA Jellyfin Plugin',
+      deviceName: 'IINA',
+      deviceId: 'test-device',
+      version: '0.7.2',
+    },
+    getHttpClient() {
+      return {
+        async get(url, options) {
+          requests.push({ url, options });
+          if (url.endsWith('/System/Info')) {
+            return { status: 200, data: { ServerName: 'Test Jellyfin' } };
+          }
+          return { status: 200, data: { Id: 'user-id', Name: 'Test User' } };
+        },
+      };
+    },
+    updateServerStatus() {},
+    hideLoginForm() {},
+    showMainContent() {},
+    showLogoutButton() {},
+    loadHomeTab() {},
+  };
+
+  await client.connectToServer({
+    id: 'server-id',
+    serverUrl: 'https://media.example.com',
+    accessToken: 'secret-token',
+  });
+
+  assert.equal(requests.length, 2);
+  for (const request of requests) {
+    assert.match(request.options.headers.Authorization, /^MediaBrowser /);
+    assert.match(request.options.headers.Authorization, /Token="secret-token"/);
+    assert.equal(request.options.headers['X-Emby-Token'], undefined);
+  }
+});
+
+test('sidebar lists and media URLs use Jellyfin 12 credentials', async () => {
+  const container = { innerHTML: '' };
+  const requests = [];
+  const authMethods = loadSidebarMethods(
+    'src/ui/sidebar/lib/auth-server-methods.js',
+    'createSidebarAuthServerMethods'
+  );
+  const mediaMethods = loadSidebarMethods(
+    'src/ui/sidebar/lib/media-methods.js',
+    'createSidebarMediaMethods',
+    {
+      document: {
+        getElementById() {
+          return container;
+        },
+      },
+      URLSearchParams,
+    }
+  );
+  const client = {
+    ...authMethods,
+    ...mediaMethods,
+    clientIdentity: {
+      clientName: 'IINA Jellyfin Plugin',
+      deviceName: 'IINA',
+      deviceId: 'test-device',
+      version: '0.7.2',
+    },
+    currentServer: {
+      url: 'https://media.example.com',
+      accessToken: 'secret-token',
+    },
+    currentUser: { Id: 'user-id', Name: 'Test User' },
+    getHttpClient() {
+      return {
+        async get(url, options) {
+          requests.push({ url, options });
+          return { status: 200, data: [] };
+        },
+      };
+    },
+    renderMediaList() {},
+  };
+
+  await client.loadRecentItems();
+
+  assert.match(requests[0].options.headers.Authorization, /^MediaBrowser /);
+  assert.match(requests[0].options.headers.Authorization, /Token="secret-token"/);
+  assert.equal(requests[0].options.headers['X-Emby-Token'], undefined);
+  assert.match(client.buildStreamUrl({ Id: 'item-id', Type: 'Episode' }), /[?&]ApiKey=/);
+  assert.doesNotMatch(client.buildStreamUrl({ Id: 'item-id', Type: 'Episode' }), /api_key=/);
+});
+
+test('source contains no legacy Jellyfin credential transport', () => {
+  const sourceFiles = [
+    'src/lib/autoplay-manager.js',
+    'src/lib/jellyfin-api.js',
+    'src/lib/media-actions.js',
+    'src/lib/playback-tracking.js',
+    'src/ui/sidebar/lib/auth-server-methods.js',
+    'src/ui/sidebar/lib/media-methods.js',
+  ];
+
+  for (const file of sourceFiles) {
+    const source = readFileSync(file, 'utf8');
+    assert.doesNotMatch(source, /X-Emby-Token/);
+    assert.doesNotMatch(source, /[?&]api_key=/);
+  }
+});


### PR DESCRIPTION
## Summary

- send authenticated sidebar requests with Jellyfin's supported `Authorization: MediaBrowser ... Token="..."` header
- use the modern `ApiKey` query parameter for images, subtitles, and direct media URLs
- add focused coverage for saved-session reconnects, sidebar listings, stream URLs, and accidental legacy credential transport

## Why

Jellyfin 12 disables legacy authorization on existing servers. Password and Quick Connect login already used the modern authorization header, so login could succeed while subsequent sidebar requests using `X-Emby-Token` returned 401 and rendered empty lists. Lowercase `api_key` media and image URLs are gated by the same legacy setting.

## Evidence

Validated this branch against a live Jellyfin 12.0.0 server with legacy authorization disabled:

- Recently Added returned 15 items
- Continue Watching returned 20 items
- Next Up returned 12 items
- a known series returned both expected episodes
- a primary image request returned HTTP 200
- a ranged direct-stream request returned HTTP 206

Checks:

- `pnpm test` (3 tests passed)
- `pnpm run check`

The live-server evidence remains local because it exercises a private media server; the committed tests reproduce the credential transport and URL behavior without credentials.
